### PR TITLE
fix: index coverage in dashboard + wire_pipeline logging

### DIFF
--- a/crates/corvia-cli/src/main.rs
+++ b/crates/corvia-cli/src/main.rs
@@ -2236,6 +2236,8 @@ pub(crate) async fn wire_pipeline_relations(
     graph: &dyn GraphStore,
 ) -> usize {
     let mut relations_stored = 0;
+    let mut source_miss = 0u64;
+    let mut target_miss = 0u64;
     for rel in relations {
         // Find the source chunk by (source_file, start_line) match
         let from_idx = processed.iter().position(|pc| {
@@ -2243,7 +2245,16 @@ pub(crate) async fn wire_pipeline_relations(
         });
         let from_uuid = match from_idx {
             Some(idx) if idx < stored_ids.len() => stored_ids[idx],
-            _ => continue,
+            _ => {
+                source_miss += 1;
+                tracing::debug!(
+                    source_file = %rel.from_source_file,
+                    start_line = rel.from_start_line,
+                    relation = %rel.relation,
+                    "wire_pipeline_relations: source chunk not found"
+                );
+                continue;
+            }
         };
 
         // Find the target chunk by file name (and optionally symbol name)
@@ -2270,7 +2281,24 @@ pub(crate) async fn wire_pipeline_relations(
             } else {
                 relations_stored += 1;
             }
+        } else {
+            target_miss += 1;
+            tracing::debug!(
+                target_file = %rel.to_file,
+                target_name = ?rel.to_name,
+                relation = %rel.relation,
+                "wire_pipeline_relations: target chunk not found"
+            );
         }
+    }
+    if source_miss > 0 || target_miss > 0 {
+        tracing::info!(
+            total = relations.len(),
+            stored = relations_stored,
+            source_miss,
+            target_miss,
+            "wire_pipeline_relations: relation wiring summary"
+        );
     }
     relations_stored
 }

--- a/crates/corvia-common/src/dashboard.rs
+++ b/crates/corvia-common/src/dashboard.rs
@@ -76,6 +76,13 @@ pub struct DashboardStatusResponse {
     pub config: DashboardConfig,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub traces: Option<TracesData>,
+    /// Ratio of indexed entries to knowledge files on disk (0.0–1.0).
+    /// `None` when file count is unavailable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index_coverage: Option<f64>,
+    /// `true` when index coverage drops below 90%.
+    #[serde(default)]
+    pub index_stale: bool,
 }
 
 /// A single structured log entry
@@ -301,9 +308,12 @@ mod tests {
                 workspace: "test".to_string(),
             },
             traces: None,
+            index_coverage: None,
+            index_stale: false,
         };
         let json = serde_json::to_string(&resp).unwrap();
         assert!(!json.contains("traces"));
+        assert!(!json.contains("index_coverage"));
     }
 
     #[test]

--- a/crates/corvia-server/src/dashboard/mod.rs
+++ b/crates/corvia-server/src/dashboard/mod.rs
@@ -96,6 +96,33 @@ fn config_summary(cfg: &corvia_common::config::CorviaConfig) -> DashboardConfig 
     }
 }
 
+/// Count JSON knowledge files on disk and compute index coverage ratio.
+fn compute_index_coverage(
+    data_dir: &std::path::Path,
+    scope_id: &str,
+    entry_count: u64,
+) -> (Option<f64>, bool) {
+    let dir = data_dir.join("knowledge").join(scope_id);
+    if !dir.exists() {
+        return (None, false);
+    }
+    let file_count = std::fs::read_dir(&dir)
+        .map(|rd| {
+            rd.filter(|e| {
+                e.as_ref()
+                    .map(|e| e.path().extension().is_some_and(|ext| ext == "json"))
+                    .unwrap_or(false)
+            })
+            .count() as u64
+        })
+        .unwrap_or(0);
+    if file_count == 0 {
+        return (None, false);
+    }
+    let coverage = (entry_count as f64 / file_count as f64).min(1.0);
+    (Some(coverage), coverage < 0.9)
+}
+
 /// GET /api/dashboard/status
 /// Returns service health, store metrics, config summary, and optional traces.
 async fn status_handler(
@@ -150,6 +177,11 @@ async fn status_handler(
         Some(traces_data)
     };
 
+    // Index coverage: compare indexed entry_count against knowledge files on disk.
+    let (index_coverage, index_stale) = compute_index_coverage(
+        &state.data_dir, scope_id, entry_count,
+    );
+
     Json(DashboardStatusResponse {
         services,
         entry_count,
@@ -158,6 +190,8 @@ async fn status_handler(
         session_count,
         config,
         traces,
+        index_coverage,
+        index_stale,
     })
 }
 
@@ -1580,5 +1614,81 @@ mod tests {
         assert_eq!(status, axum::http::StatusCode::OK);
         // GPU handler returns a GpuStatusResponse; just verify it's valid JSON
         assert!(json.is_object(), "response should be a JSON object");
+    }
+
+    // ── compute_index_coverage unit tests ──
+
+    #[test]
+    fn coverage_dir_not_exist() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(compute_index_coverage(tmp.path(), "no-scope", 0), (None, false));
+    }
+
+    #[test]
+    fn coverage_empty_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("knowledge/test")).unwrap();
+        assert_eq!(compute_index_coverage(tmp.path(), "test", 0), (None, false));
+    }
+
+    #[test]
+    fn coverage_fully_indexed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("knowledge/test");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("a.json"), "{}").unwrap();
+        std::fs::write(dir.join("b.json"), "{}").unwrap();
+        assert_eq!(compute_index_coverage(tmp.path(), "test", 2), (Some(1.0), false));
+    }
+
+    #[test]
+    fn coverage_boundary_exactly_90_pct() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("knowledge/test");
+        std::fs::create_dir_all(&dir).unwrap();
+        for i in 0..10 {
+            std::fs::write(dir.join(format!("{i}.json")), "{}").unwrap();
+        }
+        let (cov, stale) = compute_index_coverage(tmp.path(), "test", 9);
+        assert!((cov.unwrap() - 0.9).abs() < f64::EPSILON);
+        assert!(!stale, "90% should NOT be stale (threshold is < 0.9)");
+    }
+
+    #[test]
+    fn coverage_below_90_pct_is_stale() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("knowledge/test");
+        std::fs::create_dir_all(&dir).unwrap();
+        for i in 0..10 {
+            std::fs::write(dir.join(format!("{i}.json")), "{}").unwrap();
+        }
+        let (cov, stale) = compute_index_coverage(tmp.path(), "test", 8);
+        assert!((cov.unwrap() - 0.8).abs() < f64::EPSILON);
+        assert!(stale, "80% should be stale");
+    }
+
+    #[test]
+    fn coverage_entry_count_exceeds_file_count_clamped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("knowledge/test");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("a.json"), "{}").unwrap();
+        let (cov, stale) = compute_index_coverage(tmp.path(), "test", 5);
+        assert_eq!(cov, Some(1.0));
+        assert!(!stale);
+    }
+
+    #[test]
+    fn coverage_non_json_files_ignored() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("knowledge/test");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("a.json"), "{}").unwrap();
+        std::fs::write(dir.join("b.txt"), "not json").unwrap();
+        std::fs::write(dir.join("c.bak"), "backup").unwrap();
+        // 1 json file, entry_count=1 → fully indexed
+        let (cov, stale) = compute_index_coverage(tmp.path(), "test", 1);
+        assert_eq!(cov, Some(1.0));
+        assert!(!stale);
     }
 }


### PR DESCRIPTION
## Summary
- Add `index_coverage` (float, 0-1) and `index_stale` (bool) to `GET /api/dashboard/status` — compares indexed entry count vs knowledge files on disk, flags stale when < 90%
- Add debug/info logging to `wire_pipeline_relations()` for diagnosing source/target chunk misses and zero-edge scenarios
- 7 unit tests for `compute_index_coverage` covering all branches (dir missing, empty, boundary, clamp, non-JSON filtering)

Part of: [Operational Fixes Plan](https://github.com/chunzhe10/corvia-workspace/blob/master/docs/plans/2026-03-26-operational-fixes.md)

## Test plan
- [x] `cargo test -p corvia-server -- dashboard::tests` — 20/20 pass
- [x] `cargo test -p corvia-common -- dashboard` — 7/7 pass
- [x] `cargo check --workspace` — compiles clean
- [ ] Manual: verify `/api/dashboard/status` returns `index_coverage` and `index_stale` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)