### PR TITLE
fix: warn when 0 graph relations stored during ingest

### DIFF
--- a/crates/corvia-cli/src/main.rs
+++ b/crates/corvia-cli/src/main.rs
@@ -829,13 +829,22 @@ async fn cmd_ingest(path: Option<&str>, incremental: bool, files: &[String]) -> 
                 }
 
             // Wire graph edges from pipeline relations
-            if !pipeline_relations.is_empty() {
-                let edges = wire_pipeline_relations(
+            let edges = if !pipeline_relations.is_empty() {
+                wire_pipeline_relations(
                     &pipeline_relations, &chunks, &stored_ids, &*graph,
-                ).await;
-                if edges > 0 {
-                    println!("    {edges} graph relations stored");
-                }
+                ).await
+            } else {
+                0
+            };
+            if edges > 0 {
+                println!("    {edges} graph relations stored");
+            } else if chunks.len() > 10 {
+                tracing::warn!(
+                    chunks = chunks.len(),
+                    input_relations = pipeline_relations.len(),
+                    "0 graph relations stored for {} chunks — check adapter version",
+                    chunks.len()
+                );
             }
 
             println!("    Created {} entries", stored_ids.len());
@@ -921,13 +930,22 @@ async fn cmd_ingest(path: Option<&str>, incremental: bool, files: &[String]) -> 
         }
 
         // Step 5: Wire relations from pipeline (now native to ChunkingStrategy)
-        if !pipeline_relations.is_empty() {
-            let relations_stored = wire_pipeline_relations(
+        let relations_stored = if !pipeline_relations.is_empty() {
+            wire_pipeline_relations(
                 &pipeline_relations, &processed, &stored_ids, &*graph,
-            ).await;
-            if relations_stored > 0 {
-                println!("  {relations_stored} graph relations stored");
-            }
+            ).await
+        } else {
+            0
+        };
+        if relations_stored > 0 {
+            println!("  {relations_stored} graph relations stored");
+        } else if processed.len() > 10 {
+            tracing::warn!(
+                chunks = processed.len(),
+                input_relations = pipeline_relations.len(),
+                "0 graph relations stored for {} chunks — check adapter version",
+                processed.len()
+            );
         }
 
         // Step 5b: Wire doc-to-code relations
@@ -2355,13 +2373,25 @@ pub(crate) async fn wire_pipeline_relations(
         }
     }
     if source_miss > 0 || target_miss > 0 {
-        tracing::info!(
-            total = relations.len(),
-            stored = relations_stored,
-            source_miss,
-            target_miss,
-            "wire_pipeline_relations: relation wiring summary"
-        );
+        let total = relations.len();
+        // Warn when less than half of relations resolved — signals adapter/version mismatch
+        if relations_stored * 2 < total {
+            tracing::warn!(
+                total,
+                stored = relations_stored,
+                source_miss,
+                target_miss,
+                "wire_pipeline_relations: most relations failed to resolve — check adapter version"
+            );
+        } else {
+            tracing::info!(
+                total,
+                stored = relations_stored,
+                source_miss,
+                target_miss,
+                "wire_pipeline_relations: relation wiring summary"
+            );
+        }
     }
     relations_stored
 }

--- a/crates/corvia-cli/src/workspace.rs
+++ b/crates/corvia-cli/src/workspace.rs
@@ -582,13 +582,22 @@ pub async fn ingest_workspace(
         }
 
         // Wire relations from pipeline
-        if !pipeline_relations.is_empty() {
-            let relations_stored = crate::wire_pipeline_relations(
+        let relations_stored = if !pipeline_relations.is_empty() {
+            crate::wire_pipeline_relations(
                 &pipeline_relations, &processed, &stored_ids, &*graph,
-            ).await;
-            if relations_stored > 0 {
-                println!("  {relations_stored} graph relations stored");
-            }
+            ).await
+        } else {
+            0
+        };
+        if relations_stored > 0 {
+            println!("  {relations_stored} graph relations stored");
+        } else if processed.len() > 10 {
+            tracing::warn!(
+                chunks = processed.len(),
+                input_relations = pipeline_relations.len(),
+                "0 graph relations stored for {} chunks — check adapter version",
+                processed.len()
+            );
         }
 
         // Shutdown adapter
@@ -757,6 +766,8 @@ pub async fn ingest_workspace(
                                     );
                                 }
                             }
+                            // No zero-relations warning here — workspace docs
+                            // (markdown/text) are not expected to produce graph relations.
 
                             println!(
                                 "  {} chunks stored for workspace docs",


### PR DESCRIPTION
## Summary
- Adds `tracing::warn!` at 3 code-ingest call sites when `wire_pipeline_relations` returns 0 stored relations and chunk count exceeds 10
- Restructured to check the *return value* (not just the input), catching both "adapter emitted nothing" and "adapter emitted relations but none resolved"
- Added `input_relations` structured field so operators can distinguish the two failure modes
- Skips the warning for workspace docs path where zero relations is expected behavior

Closes #10

## Test plan
- [ ] `cargo check --package corvia-cli` passes (verified)
- [ ] `RUST_LOG=warn corvia workspace ingest --fresh` on a code repo — no spurious warning
- [ ] Ingest with a stale/basic adapter on >10 chunks — warning appears in logs
- [ ] Workspace docs ingest — no warning emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)