### PR TITLE
fix: review cleanup for index coverage feature

### DIFF
--- a/crates/corvia-cli/src/main.rs
+++ b/crates/corvia-cli/src/main.rs
@@ -644,7 +644,11 @@ async fn cmd_serve() -> Result<()> {
         workspace_root,
         ingest_status: Arc::new(std::sync::RwLock::new(corvia_kernel::ingest::IngestStatus::idle())),
     });
-    // Initial coverage cache population + background refresh
+    // Initial coverage cache population + background refresh.
+    // NOTE: ttl_secs is captured once at startup. While `dashboard` is in
+    // HOT_RELOADABLE_SECTIONS, `coverage_ttl_secs` changes require a server
+    // restart to take effect on the background loop. `stale_threshold` is read
+    // from the cache at construction time and also requires restart.
     {
         let cache = state.coverage_cache.clone();
         let store_bg = state.store.clone();

--- a/crates/corvia-common/src/config.rs
+++ b/crates/corvia-common/src/config.rs
@@ -140,7 +140,7 @@ impl DashboardSection {
         }
         if self.coverage_ttl_secs < MIN_COVERAGE_TTL {
             eprintln!(
-                "Warning: dashboard.coverage_ttl_secs={} below minimum {}, clamping",
+                "warning: dashboard.coverage_ttl_secs={} below minimum {}, clamping",
                 self.coverage_ttl_secs, MIN_COVERAGE_TTL
             );
             self.coverage_ttl_secs = MIN_COVERAGE_TTL;

--- a/crates/corvia-common/src/dashboard.rs
+++ b/crates/corvia-common/src/dashboard.rs
@@ -93,6 +93,28 @@ pub struct DashboardStatusResponse {
     pub index_coverage_checked_at: Option<String>,
 }
 
+/// Coverage snapshot returned by both GET /api/dashboard/status (embedded)
+/// and POST /api/dashboard/status/refresh-coverage (standalone).
+/// Shared struct ensures both endpoints stay in sync.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CoverageResponse {
+    /// Coverage ratio: HNSW entries / knowledge files on disk (0.0-1.0).
+    /// null when no knowledge files exist on disk.
+    pub index_coverage: Option<f64>,
+    /// true when coverage < threshold. null when coverage is null.
+    pub index_stale: Option<bool>,
+    /// Knowledge JSON files on disk for the default scope.
+    pub index_disk_count: u64,
+    /// Entries in Redb SCOPE_INDEX for the default scope.
+    pub index_store_count: u64,
+    /// Entries in Redb HNSW_TO_UUID table.
+    pub index_hnsw_count: u64,
+    /// Configured staleness threshold (0.0-1.0).
+    pub index_stale_threshold: f64,
+    /// ISO 8601 timestamp of last coverage computation.
+    pub index_coverage_checked_at: Option<String>,
+}
+
 /// A single structured log entry
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LogEntry {

--- a/crates/corvia-kernel/src/lite_store.rs
+++ b/crates/corvia-kernel/src/lite_store.rs
@@ -1676,4 +1676,23 @@ mod tests {
 
         assert_eq!(store.hnsw_entry_count().unwrap(), 5);
     }
+
+    #[tokio::test]
+    async fn test_hnsw_entry_count_after_delete_scope() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LiteStore::open(dir.path(), 3).unwrap();
+        store.init_schema().await.unwrap();
+
+        for _ in 0..5 {
+            let mut entry = corvia_common::types::KnowledgeEntry::new(
+                "test".into(), "scope".into(), "file.rs".into(),
+            );
+            entry.embedding = Some(vec![0.1, 0.2, 0.3]);
+            store.insert(&entry).await.unwrap();
+        }
+        assert_eq!(store.hnsw_entry_count().unwrap(), 5);
+
+        store.delete_scope("scope").await.unwrap();
+        assert_eq!(store.hnsw_entry_count().unwrap(), 0);
+    }
 }

--- a/crates/corvia-server/src/dashboard/coverage.rs
+++ b/crates/corvia-server/src/dashboard/coverage.rs
@@ -19,6 +19,20 @@ pub struct CoverageSnapshot {
     pub checked_at: Option<String>,
 }
 
+impl From<CoverageSnapshot> for corvia_common::dashboard::CoverageResponse {
+    fn from(s: CoverageSnapshot) -> Self {
+        Self {
+            index_coverage: s.coverage,
+            index_stale: s.stale,
+            index_disk_count: s.disk_count,
+            index_store_count: s.store_count,
+            index_hnsw_count: s.hnsw_count,
+            index_stale_threshold: s.threshold,
+            index_coverage_checked_at: s.checked_at,
+        }
+    }
+}
+
 /// Cached index coverage metrics with TTL-based refresh.
 ///
 /// Uses `std::sync::Mutex` with brief lock holds (never across `.await`).
@@ -478,5 +492,41 @@ mod tests {
         cache.refresh(tmp.path(), "test", &store).await;
         // Immediately after refresh with 0s TTL, needs_refresh is true
         assert!(cache.needs_refresh());
+    }
+
+    #[test]
+    fn test_count_json_files_ignores_subdirectories() {
+        let tmp = tempdir().unwrap();
+        let dir = tmp.path().join("scope");
+        std::fs::create_dir_all(&dir).unwrap();
+        // 2 json files at top level
+        std::fs::write(dir.join("a.json"), "{}").unwrap();
+        std::fs::write(dir.join("b.json"), "{}").unwrap();
+        // 3 json files in a subdirectory (should NOT be counted)
+        let sub = dir.join("subdir");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(sub.join("c.json"), "{}").unwrap();
+        std::fs::write(sub.join("d.json"), "{}").unwrap();
+        std::fs::write(sub.join("e.json"), "{}").unwrap();
+        assert_eq!(count_json_files(&dir), 2);
+    }
+
+    #[test]
+    fn test_checked_at_is_valid_rfc3339() {
+        // Verify CoverageSnapshot.checked_at is valid RFC 3339 after refresh
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let tmp = tempdir().unwrap();
+            let store = make_store(tmp.path());
+            store.init_schema().await.unwrap();
+
+            let cache = IndexCoverageCache::new(0.9, 60);
+            let snap = cache.refresh(tmp.path(), "test", &store).await;
+            let ts = snap.checked_at.expect("checked_at should be set after refresh");
+            assert!(
+                chrono::DateTime::parse_from_rfc3339(&ts).is_ok(),
+                "checked_at should be valid RFC 3339: {ts}"
+            );
+        });
     }
 }

--- a/crates/corvia-server/src/dashboard/mod.rs
+++ b/crates/corvia-server/src/dashboard/mod.rs
@@ -180,7 +180,7 @@ async fn status_handler(
 /// Force-recompute coverage and return fresh snapshot.
 async fn refresh_coverage_handler(
     State(state): State<Arc<AppState>>,
-) -> Json<serde_json::Value> {
+) -> Json<corvia_common::dashboard::CoverageResponse> {
     let scope_id = state
         .default_scope_id
         .as_deref()
@@ -190,15 +190,7 @@ async fn refresh_coverage_handler(
         .refresh(&state.data_dir, scope_id, &*state.store)
         .await;
 
-    Json(serde_json::json!({
-        "index_coverage": snapshot.coverage,
-        "index_stale": snapshot.stale,
-        "index_disk_count": snapshot.disk_count,
-        "index_store_count": snapshot.store_count,
-        "index_hnsw_count": snapshot.hnsw_count,
-        "index_stale_threshold": snapshot.threshold,
-        "index_coverage_checked_at": snapshot.checked_at,
-    }))
+    Json(snapshot.into())
 }
 
 /// GET /api/dashboard/traces
@@ -1761,6 +1753,74 @@ mod tests {
         assert_eq!(status, axum::http::StatusCode::OK);
         // GPU handler returns a GpuStatusResponse; just verify it's valid JSON
         assert!(json.is_object(), "response should be a JSON object");
+    }
+
+    #[tokio::test]
+    async fn test_status_coverage_with_data() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state(tmp.path()).await;
+
+        // Insert 7 entries (creates knowledge JSON files on disk + store + HNSW)
+        let scope_id = corvia_common::constants::DEFAULT_SCOPE_ID;
+        for _ in 0..7 {
+            let mut entry = corvia_common::types::KnowledgeEntry::new(
+                "test content".into(), scope_id.into(), "test.rs".into(),
+            );
+            entry.embedding = Some(vec![0.1, 0.2, 0.3]);
+            state.store.insert(&entry).await.unwrap();
+        }
+        // Add 3 extra JSON files to simulate partial ingest
+        let knowledge_dir = tmp.path().join("knowledge").join(scope_id);
+        for i in 0..3 {
+            std::fs::write(
+                knowledge_dir.join(format!("extra-{i}.json")),
+                format!(r#"{{"extra":{i}}}"#),
+            ).unwrap();
+        }
+
+        // Refresh coverage cache so status has data
+        state.coverage_cache
+            .refresh(&state.data_dir, scope_id, &*state.store)
+            .await;
+
+        let (status, json) = get_json(state, "/api/dashboard/status").await;
+
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(json["index_disk_count"], 10);
+        assert_eq!(json["index_store_count"], 7);
+        assert_eq!(json["index_hnsw_count"], 7);
+        assert_eq!(json["index_coverage"], 0.7);
+        assert_eq!(json["index_stale"], true);
+        assert_eq!(json["index_stale_threshold"], 0.9);
+        assert!(json["index_coverage_checked_at"].is_string(), "checked_at should be a string");
+    }
+
+    #[tokio::test]
+    async fn test_refresh_populates_cache_for_status() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state(tmp.path()).await;
+
+        // Status before any refresh — cache has defaults
+        let (_, json_before) = get_json(state.clone(), "/api/dashboard/status").await;
+        assert!(json_before["index_coverage"].is_null());
+        assert!(json_before["index_coverage_checked_at"].is_null());
+
+        // POST refresh-coverage to populate the cache
+        let app = router(state.clone());
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/api/dashboard/status/refresh-coverage")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+
+        // Status after refresh — checked_at should now be set
+        let (_, json_after) = get_json(state, "/api/dashboard/status").await;
+        assert!(
+            json_after["index_coverage_checked_at"].is_string(),
+            "after refresh, checked_at should be set"
+        );
     }
 
 }


### PR DESCRIPTION
## Summary
- Remove dead `compute_index_coverage` function and its 7 tests (replaced by `IndexCoverageCache` in coverage.rs)
- Add typed `CoverageResponse` struct shared between status and refresh endpoints (eliminates untyped `serde_json::Value` divergence risk)
- Add 5 missing tests identified by 5-persona review (integration with data, refresh→status flow, LiteStore delete, subdirectory exclusion, RFC 3339 validation)
- Document TTL hot-reload limitation in background refresh loop

## Changes
- **corvia-common**: Add `CoverageResponse` DTO, fix `eprintln` format in config validation
- **corvia-server**: Type refresh handler, remove dead code + stale tests, add integration tests
- **corvia-kernel**: Add `test_hnsw_entry_count_after_delete_scope`
- **corvia-cli**: Document TTL hot-reload limitation

## Test Plan
- [x] Unit tests pass (cargo test — 726+ tests)
- [x] Build clean, no warnings
- [x] E2E: status endpoint returns all 7 index_ fields
- [x] E2E: refresh endpoint returns typed CoverageResponse
- [x] E2E: field sets match between status and refresh
- [x] Edge cases: fresh workspace (null), full coverage (1.0), orphaned entries (clamped)

## Review
5-persona review completed:
- Senior SWE: No Critical. 3 Important (concurrent refresh, TTL reload, scope ID) — addressed TTL doc, others deferred
- Product Manager: No Critical. 3 Important (config wiring verified, typed response fixed, scope_id deferred)
- QA Engineer: 2 Critical (missing integration tests with data) — fixed
- API Design Reviewer: 3 Important (typed response, nesting deferred, error propagation deferred)
- UX Designer: 1 Critical (remediation hint — deferred as new feature), 4 Important (terminology, orphans — deferred)

Addresses review findings from chunzhe10/corvia#10

🤖 Generated with [Claude Code](https://claude.com/claude-code)