### PR TITLE
feat: access tracking in retrieval path

### DIFF
--- a/crates/corvia-kernel/src/lite_store.rs
+++ b/crates/corvia-kernel/src/lite_store.rs
@@ -687,6 +687,9 @@ impl super::traits::QueryableStore for LiteStore {
         Ok(results)
     }
 
+    /// Access metadata is Redb-only — not persisted to knowledge JSON files.
+    /// This is intentional: access counts are ephemeral operational data and
+    /// will be reset on `rebuild_from_files`. See trait doc for rationale.
     #[tracing::instrument(name = "corvia.access.record", skip(self), fields(count = entry_ids.len()))]
     async fn record_access(&self, entry_ids: &[uuid::Uuid]) -> Result<()> {
         if entry_ids.is_empty() {

--- a/crates/corvia-kernel/src/postgres_store.rs
+++ b/crates/corvia-kernel/src/postgres_store.rs
@@ -194,6 +194,21 @@ impl crate::traits::QueryableStore for PostgresStore {
             .await
             .map_err(|e| CorviaError::Storage(format!("Failed to create HNSW index: {e}")))?;
 
+        // Add tiered-knowledge columns to existing tables (idempotent migration).
+        sqlx::query(
+            "ALTER TABLE knowledge ADD COLUMN IF NOT EXISTS last_accessed TIMESTAMPTZ"
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|e| CorviaError::Storage(format!("Failed to add last_accessed column: {e}")))?;
+
+        sqlx::query(
+            "ALTER TABLE knowledge ADD COLUMN IF NOT EXISTS access_count INTEGER NOT NULL DEFAULT 0"
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|e| CorviaError::Storage(format!("Failed to add access_count column: {e}")))?;
+
         info!("PostgreSQL schema initialized (embedding dim={dim})");
         Ok(())
     }
@@ -335,19 +350,21 @@ impl crate::traits::QueryableStore for PostgresStore {
         Ok(row.as_ref().and_then(row_to_entry))
     }
 
+    #[tracing::instrument(name = "corvia.access.record", skip(self), fields(count = entry_ids.len()))]
     async fn record_access(&self, entry_ids: &[uuid::Uuid]) -> Result<()> {
         if entry_ids.is_empty() {
             return Ok(());
         }
 
-        let ids: Vec<Uuid> = entry_ids.to_vec();
+        // SQL integer addition is safe here: access_count is INTEGER (max 2^31-1).
+        // Overflow is unreachable in practice (would require billions of accesses per entry).
         if let Err(e) = sqlx::query(
             r#"UPDATE knowledge
                SET last_accessed = NOW(),
                    access_count = access_count + 1
                WHERE id = ANY($1)"#,
         )
-        .bind(&ids)
+        .bind(entry_ids)
         .execute(&self.pool)
         .await
         {

--- a/crates/corvia-kernel/src/retriever.rs
+++ b/crates/corvia-kernel/src/retriever.rs
@@ -71,8 +71,9 @@ fn spawn_access_recording(store: Arc<dyn QueryableStore>, results: &[SearchResul
     }
     let entry_ids: Vec<uuid::Uuid> = results.iter().map(|sr| sr.entry.id).collect();
     tokio::spawn(async move {
-        if let Err(e) = store.record_access(&entry_ids).await {
-            warn!(error = %e, "Access recording failed");
+        match store.record_access(&entry_ids).await {
+            Ok(()) => {}
+            Err(e) => warn!(error = %e, "Access recording failed"),
         }
     });
 }
@@ -1099,7 +1100,7 @@ mod tests {
         assert!(!result.results.is_empty());
 
         // Give the spawned task time to complete.
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
         // Verify access tracking updated for returned entries.
         let returned_ids: Vec<uuid::Uuid> = result.results.iter().map(|sr| sr.entry.id).collect();
@@ -1111,7 +1112,7 @@ mod tests {
 
         // Search again — access_count should increment to 2.
         let _result2 = retriever.retrieve("test", "access-scope", &opts).await.unwrap();
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
         for id in &returned_ids {
             let entry = store.get(id).await.unwrap().unwrap();

--- a/crates/corvia-kernel/src/traits.rs
+++ b/crates/corvia-kernel/src/traits.rs
@@ -36,6 +36,10 @@ pub trait QueryableStore: Send + Sync {
     /// Record access for a batch of entries (updates last_accessed and access_count).
     /// All updates are batched into a single write transaction.
     /// Failures are non-fatal — implementations should log warnings, not propagate errors.
+    ///
+    /// Access metadata is ephemeral: LiteStore persists to Redb only (not knowledge
+    /// JSON files), so access counts are reset on `rebuild_from_files`. This is
+    /// intentional — access tracking is operational telemetry, not source-of-truth data.
     async fn record_access(&self, entry_ids: &[uuid::Uuid]) -> Result<()>;
 
     /// Downcast support for store-specific operations (e.g., LiteStore::rebuild_from_files).


### PR DESCRIPTION
## Summary
- Record `last_accessed` and `access_count` when entries are returned via retrieval pipeline
- Adds `record_access()` to `QueryableStore` trait with LiteStore (batched Redb txn) and PostgresStore (batched SQL UPDATE) implementations
- Retriever spawns fire-and-forget background task to avoid blocking search responses

## Changes
- **traits.rs**: Added `record_access(entry_ids)` to `QueryableStore` with ephemeral-data documentation
- **lite_store.rs**: Batched Redb write transaction implementation with graceful error handling
- **postgres_store.rs**: Batched `UPDATE ... WHERE id = ANY($1)`, schema migration via `ALTER TABLE ADD COLUMN IF NOT EXISTS`, tracing instrumentation
- **retriever.rs**: `spawn_access_recording()` helper called from both `VectorRetriever` and `GraphExpandRetriever` after final result assembly

## Test Plan
- [x] Unit tests pass (`cargo test --workspace` — 788 passed, 0 failed)
- [x] Clippy clean on changed files
- [x] `test_record_access_updates_fields` — verifies access_count and last_accessed update
- [x] `test_record_access_batch` — verifies single-txn batch semantics
- [x] `test_record_access_nonexistent_entry_graceful` — verifies graceful handling of missing entries
- [x] `test_access_tracking_increments_on_retrieval` — end-to-end retriever integration test
- [x] `test_access_tracking_empty_results_noop` — empty results don't trigger write
- [x] Edge case: concurrent access recording serialized by Redb SWMR

## Review
5-persona review completed:
- Senior SWE: Approved — consistent with existing codebase patterns, 3 Important items addressed
- Product Manager: Approved — meets all acceptance criteria, correct placement in pipeline
- QA Engineer: Approved — 8 tests cover core acceptance criteria
- Performance Engineer: Approved — fire-and-forget non-blocking, PostgresStore efficient
- Database/Storage Specialist: Approved — migration gap fixed, transaction safety confirmed

## Design Decisions
- Access metadata is **ephemeral** (Redb-only in LiteStore, not persisted to knowledge JSON files). Reset on `rebuild_from_files`. This is intentional — access tracking is operational telemetry, not source-of-truth data.
- Pre-existing pattern: sync Redb I/O on async runtime (all LiteStore methods do this). Not addressed in this PR to avoid scope creep.

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)