### PR TITLE
feat: tier-aware retrieval scoring (#22)

### DIFF
--- a/crates/corvia-kernel/src/retriever.rs
+++ b/crates/corvia-kernel/src/retriever.rs
@@ -238,7 +238,7 @@ impl Retriever for VectorRetriever {
         // Apply tier_weight multiplier: deprioritize Warm/Cold, exclude Forgotten.
         // Fast path: skip filter/map/re-sort when all entries are Hot (common case).
         let any_non_hot = merged.iter().any(|sr| sr.entry.tier != Tier::Hot);
-        let mut tier_weighted = if any_non_hot {
+        let tier_weighted = if any_non_hot {
             let mut weighted: Vec<SearchResult> = merged
                 .into_iter()
                 .filter(|sr| sr.entry.tier != Tier::Forgotten)
@@ -1724,13 +1724,14 @@ mod tests {
             store.insert(&entry).await.unwrap();
         }
 
-        // Warm entry with LOW cosine similarity to query [1,0,0].
+        // Warm entry with moderate cosine similarity to query [1,0,0].
+        // cosine([0.4,0.9,0.0], [1,0,0]) ≈ 0.407 → weighted: 0.407 * 0.7 ≈ 0.285
         let mut warm = KnowledgeEntry::new(
             "warm low cosine".to_string(),
             "rank-scope".to_string(),
             "v1".to_string(),
         );
-        warm.embedding = Some(vec![0.0, 1.0, 0.0]); // orthogonal to query → cosine ~0
+        warm.embedding = Some(vec![0.4, 0.9, 0.0]); // moderate similarity to query
         warm.tier = Tier::Warm;
         store.insert(&warm).await.unwrap();
 


### PR DESCRIPTION
## Summary
- Add `tier_weight` multiplier to retrieval scoring: Hot=1.0, Warm=0.7, Cold=0.3, Forgotten=0.0
- Applied after cosine similarity in both VectorRetriever and GraphExpandRetriever
- Forgotten entries excluded entirely from search results
- Hot-only fast path avoids unnecessary re-sort/allocation for common case

## Changes
- `crates/corvia-kernel/src/retriever.rs`:
  - `tier_weight()` function mapping Tier → f32 multiplier
  - VectorRetriever: tier weighting after cosine similarity with Hot-only fast path
  - GraphExpandRetriever: tier weighting on all scoring paths (direct hits, hop-1, hop-2, cold scan)
  - `merge_cold_results`: simplified (tier weighting deferred to caller)
  - `sort_unstable_by` for score ordering (no stability requirement)

## Test Plan
- [x] Unit tests pass (`cargo test --workspace` — 0 failures)
- [x] Clippy clean on changed crate (`cargo clippy -p corvia-kernel`)
- [x] `test_tier_weight_values` — verifies weight mapping
- [x] `test_hot_ranks_above_warm_same_cosine` — Hot outranks Warm at equal cosine
- [x] `test_tier_weight_score_ratio` — verifies exact 0.7 ratio warm/hot
- [x] `test_forgotten_entry_never_in_results` — Forgotten excluded from VectorRetriever
- [x] `test_graph_expand_excludes_forgotten` — Forgotten excluded from GraphExpandRetriever
- [x] `test_cold_high_cosine_above_warm_low_cosine` — Cold(0.3) with high cosine beats Warm(0.7) with low cosine
- [x] `test_all_forgotten_returns_empty` — all-Forgotten scope returns empty results

## Review
5-persona review completed:
- Senior SWE: Approved (Critical double-weighting bug caught and fixed, Important items addressed)
- Product Manager: Approved (all 7 acceptance criteria met, scope clean)
- QA Engineer: Approved (score-ratio test and all-Forgotten test added per recommendation)
- Performance Engineer: Approved (Hot-only fast path, sort_unstable_by, redundant sort removed)
- Rust Idiom Reviewer: Approved (Tier by value, pub(crate), #[inline], const fn)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)