### PR TITLE
fix: E2E container labels collide with devcontainer

### DIFF
--- a/tests/integration/docker_mcp_e2e_test.rs
+++ b/tests/integration/docker_mcp_e2e_test.rs
@@ -230,10 +230,17 @@ exec corvia serve
             .trim()
             .to_string();
 
+        // Override compose labels inherited from the devcontainer image so that
+        // VS Code does not mistake E2E containers for the real devcontainer.
+        // Uses the unique container_name so multiple E2E instances never collide.
+        let label_project = format!("com.docker.compose.project={container_name}");
+        let label_service = format!("com.docker.compose.service={container_name}");
         let status = Command::new("docker")
             .args([
                 "run", "-d",
                 "--name", &container_name,
+                "--label", &label_project,
+                "--label", &label_service,
                 &format!("--network=container:{hostname}"),
                 "-v", &format!("{}/repos/corvia/target/debug/corvia:/usr/local/bin/corvia:ro", host_workspace),
                 "-v", &format!("{}/repos/corvia/target/debug/corvia-inference:/usr/local/bin/corvia-inference:ro", host_workspace),


### PR DESCRIPTION
## Summary
- Docker Compose bakes `com.docker.compose.project` labels into the devcontainer image at build time
- E2E test containers created via `docker run` inherit these labels, causing VS Code to mistake them for the real devcontainer ("workspace does not exist" error)
- Override with unique per-container labels (`com.docker.compose.project=corvia-e2e-{PID}`) so multiple E2E instances can coexist without conflicting with the devcontainer or each other

## Test plan
- [ ] Run `make test-e2e-docker` — verify E2E tests still pass
- [ ] With E2E container running, open corvia-workspace in devcontainer — verify no "workspace does not exist" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)