### PR TITLE
feat: fresh re-ingest with agent preservation and quality filters

### DIFF
--- a/crates/corvia-cli/src/workspace.rs
+++ b/crates/corvia-cli/src/workspace.rs
@@ -333,12 +333,13 @@ pub use corvia_kernel::ingest::infer_source_origin;
 /// Creates its own store/graph/engine for standalone CLI use, then delegates
 /// to [`corvia_kernel::ingest::run_workspace_ingest`] for the actual pipeline.
 ///
-/// The `fresh` parameter is accepted but not yet used (future: delete existing
-/// entries before re-ingest).
+/// When `fresh` is true, all ingested entries are deleted while agent-written
+/// entries (those with `agent_id`) are preserved and re-inserted into the
+/// rebuilt store.
 pub async fn ingest_workspace(
     root: &Path,
     repo_filter: Option<&str>,
-    _fresh: bool,
+    fresh: bool,
 ) -> Result<()> {
     let config_path = root.join("corvia.toml");
     let config = CorviaConfig::load(&config_path)?;
@@ -346,6 +347,36 @@ pub async fn ingest_workspace(
     let data_dir = root.join(&config.storage.data_dir);
     let (store, graph) = corvia_kernel::create_store_at_with_graph(&config, &data_dir).await?;
     let engine = corvia_kernel::create_engine(&config);
+
+    if fresh {
+        let scope_id = &config.project.scope_id;
+
+        // Read agent-written entries before nuking the scope
+        let all_entries = corvia_kernel::knowledge_files::read_scope(&data_dir, scope_id)?;
+        let agent_entries: Vec<_> = all_entries
+            .into_iter()
+            .filter(|e| e.agent_id.is_some())
+            .collect();
+
+        println!(
+            "Fresh mode: preserving {} agent-written entries, deleting scope...",
+            agent_entries.len()
+        );
+
+        store.delete_scope(scope_id).await?;
+
+        // Restore agent entries with fresh embeddings
+        if !agent_entries.is_empty() {
+            let texts: Vec<String> = agent_entries.iter().map(|e| e.content.clone()).collect();
+            let embeddings = engine.embed_batch(&texts).await?;
+            for (mut entry, embedding) in agent_entries.into_iter().zip(embeddings) {
+                entry.auto_classify();
+                entry.embedding = Some(embedding);
+                store.insert(&entry).await?;
+            }
+            println!("  Restored agent entries.");
+        }
+    }
 
     let progress = corvia_kernel::ingest::PrintProgress;
     corvia_kernel::ingest::run_workspace_ingest(corvia_kernel::ingest::WorkspaceIngestCtx {

--- a/crates/corvia-kernel/src/ingest.rs
+++ b/crates/corvia-kernel/src/ingest.rs
@@ -204,6 +204,31 @@ pub fn infer_source_origin(repo_name: Option<&str>, source_file: &str) -> Option
     Some("workspace".into())
 }
 
+const MIN_CONTENT_LENGTH: usize = 80;
+
+const INGEST_EXCLUDED_FILES: &[&str] = &[
+    "CHANGELOG.md",
+    "package.json",
+    "package-lock.json",
+];
+
+fn content_passes_min_length(content: &str) -> bool {
+    let stripped: String = content
+        .lines()
+        .filter(|line| !line.starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n");
+    stripped.trim().len() >= MIN_CONTENT_LENGTH
+}
+
+pub fn is_excluded_file(source_file: &str) -> bool {
+    let file_name = std::path::Path::new(source_file)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+    INGEST_EXCLUDED_FILES.contains(&file_name)
+}
+
 /// Simple glob matching for blocked paths (supports trailing `*` only).
 pub fn blocked_path_match(pattern: &str, path: &str) -> bool {
     if let Some(prefix) = pattern.strip_suffix('*') {
@@ -475,6 +500,7 @@ async fn semantic_subsplit(
                 content_role: None,
                 source_origin: None,
             };
+            entry.auto_classify();
             entry.embedding = Some(embedding);
 
             match store.insert(&entry).await {
@@ -627,9 +653,12 @@ pub async fn run_workspace_ingest(ctx: WorkspaceIngestCtx<'_>) -> anyhow::Result
         process.spawn().map_err(|e| anyhow::anyhow!(e))?;
 
         // Ingest source files via IPC
-        let source_files = process
+        let source_files: Vec<_> = process
             .ingest(repo_path_str, &config.project.scope_id)
-            .map_err(|e| anyhow::anyhow!(e))?;
+            .map_err(|e| anyhow::anyhow!(e))?
+            .into_iter()
+            .filter(|sf| !is_excluded_file(&sf.metadata.file_path))
+            .collect();
 
         // Build chunking pipeline with adapter strategies
         let mut pipeline = crate::create_chunking_pipeline(config);
@@ -687,8 +716,10 @@ pub async fn run_workspace_ingest(ctx: WorkspaceIngestCtx<'_>) -> anyhow::Result
                             &pc.metadata.source_file,
                         )),
                 };
+                entry.auto_classify();
                 entry
             })
+            .filter(|e| content_passes_min_length(&e.content))
             .collect();
 
         let total = entries.len();
@@ -813,7 +844,7 @@ pub async fn run_workspace_ingest(ctx: WorkspaceIngestCtx<'_>) -> anyhow::Result
                         let is_blocked = blocked
                             .iter()
                             .any(|bp| blocked_path_match(bp, path));
-                        in_allowed && !is_blocked
+                        in_allowed && !is_blocked && !is_excluded_file(path)
                     })
                     .collect();
 
@@ -860,8 +891,10 @@ pub async fn run_workspace_ingest(ctx: WorkspaceIngestCtx<'_>) -> anyhow::Result
                                     .and_then(|m| m.source_origin.clone())
                                     .or_else(|| infer_source_origin(None, &pc.metadata.source_file)),
                             };
+                            entry.auto_classify();
                             entry
                         })
+                        .filter(|e| content_passes_min_length(&e.content))
                         .collect();
 
                     let total = entries.len();

--- a/crates/corvia-kernel/src/knowledge_files.rs
+++ b/crates/corvia-kernel/src/knowledge_files.rs
@@ -107,6 +107,41 @@ pub fn delete_entry(data_dir: &Path, scope_id: &str, entry_id: &Uuid) -> Result<
     Ok(())
 }
 
+/// Delete ingested (non-agent-written) entry files in a scope.
+/// Returns (deleted_count, preserved_count).
+pub fn purge_ingested_files(data_dir: &Path, scope_id: &str) -> Result<(usize, usize)> {
+    validate_scope_id(scope_id)?;
+    let dir = scope_dir(data_dir, scope_id);
+    if !dir.exists() {
+        return Ok((0, 0));
+    }
+    let mut deleted = 0;
+    let mut preserved = 0;
+    for file in std::fs::read_dir(&dir)
+        .map_err(|e| CorviaError::Storage(format!("Failed to read dir: {e}")))?
+    {
+        let file = file.map_err(|e| CorviaError::Storage(e.to_string()))?;
+        let path = file.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let json = std::fs::read_to_string(&path).map_err(|e| {
+            CorviaError::Storage(format!("Failed to read {}: {e}", path.display()))
+        })?;
+        if let Ok(entry) = serde_json::from_str::<KnowledgeEntry>(&json) {
+            if entry.agent_id.is_some() {
+                preserved += 1;
+            } else {
+                std::fs::remove_file(&path).map_err(|e| {
+                    CorviaError::Storage(format!("Failed to delete {}: {e}", path.display()))
+                })?;
+                deleted += 1;
+            }
+        }
+    }
+    Ok((deleted, preserved))
+}
+
 /// Delete all entry files in a scope (removes the scope directory).
 pub fn delete_scope_files(data_dir: &Path, scope_id: &str) -> Result<()> {
     validate_scope_id(scope_id)?;


### PR DESCRIPTION
## Summary
- Add `purge_ingested_files` to `knowledge_files.rs` for selective deletion of non-agent entries
- Add ingestion quality filters: min content length (80 chars), excluded files list, `auto_classify()` on all entry paths
- Wire fresh mode in `ingest_workspace`: preserves agent-written entries through scope rebuild by re-embedding and reinserting them

## Test plan
- [ ] `cargo build --workspace` passes
- [ ] `cargo test --workspace` passes
- [ ] `corvia workspace ingest --fresh` deletes ingested entries and preserves agent-written ones
- [ ] Entries below 80 chars (excluding headings) are filtered out
- [ ] CHANGELOG.md, package.json, package-lock.json are excluded from ingestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)