### PR TITLE
fix(ci): remove v1 binary references from release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,15 +47,12 @@ jobs:
             ${{ runner.os }}-cargo-registry-
 
       - name: Build release binaries
-        run: cargo build --release -p corvia-cli -p corvia-inference -p corvia-adapter-basic -p corvia-adapter-git
+        run: cargo build --release -p corvia
 
       - name: Prepare release assets
         run: |
           cp target/release/corvia corvia-cli-linux-amd64
-          cp target/release/corvia-inference corvia-inference-linux-amd64
-          cp target/release/corvia-adapter-basic corvia-adapter-basic-linux-amd64
-          cp target/release/corvia-adapter-git corvia-adapter-git-linux-amd64
-          chmod +x corvia-cli-linux-amd64 corvia-inference-linux-amd64 corvia-adapter-basic-linux-amd64 corvia-adapter-git-linux-amd64
+          chmod +x corvia-cli-linux-amd64
 
           # ORT execution provider shared libraries (cp -L resolves symlinks from ort cache)
           for lib in libonnxruntime_providers_shared libonnxruntime_providers_cuda libonnxruntime_providers_openvino; do
@@ -68,12 +65,8 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          fail_on_unmatched_files: false
           files: |
             corvia-cli-linux-amd64
-            corvia-inference-linux-amd64
-            corvia-adapter-basic-linux-amd64
-            corvia-adapter-git-linux-amd64
-            libonnxruntime_providers_shared-linux-amd64.so
-            libonnxruntime_providers_cuda-linux-amd64.so
-            libonnxruntime_providers_openvino-linux-amd64.so
+            libonnxruntime_providers_*-linux-amd64.so
           generate_release_notes: true


### PR DESCRIPTION
## Summary
- Remove `corvia-inference`, `corvia-adapter-basic`, `corvia-adapter-git` from `cargo build`, asset prep, and release upload — these crates no longer exist in v2
- Fix package name: `-p corvia-cli` → `-p corvia` (the actual Cargo package name)
- Add `fail_on_unmatched_files: false` so optional ORT shared libraries don't fail the release step
- Use glob pattern `libonnxruntime_providers_*-linux-amd64.so` instead of listing each file

## Context
The v2 refactor consolidated the separate inference server and adapter binaries into the single `corvia` CLI. The release workflow was never updated, so the first v2 tag push would fail CI at the `cargo build` step.

## Test plan
- [ ] Verify `cargo build --release -p corvia` succeeds locally
- [ ] Verify `target/release/corvia` binary is produced
- [ ] Push a test tag to validate the workflow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)