### PR TITLE
feat: add HTTP MCP transport (corvia serve)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,8 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -232,10 +234,15 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -256,6 +263,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -522,6 +530,7 @@ name = "corvia"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "axum",
  "clap",
  "corvia-core",
  "opentelemetry",
@@ -3019,6 +3028,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3724,6 +3744,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3762,6 +3783,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ uuid = { version = "1", features = ["v7"] }
 
 # MCP
 rmcp = { version = "0.1", features = ["server", "transport-io"] }
+axum = { version = "0.7", features = ["http1"] }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/corvia-cli/Cargo.toml
+++ b/crates/corvia-cli/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 corvia-core = { path = "../corvia-core" }
 rmcp.workspace = true
+axum.workspace = true
 clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/corvia-cli/src/main.rs
+++ b/crates/corvia-cli/src/main.rs
@@ -89,6 +89,15 @@ enum Command {
         #[arg(long)]
         test: bool,
     },
+    /// Start HTTP MCP server (multi-client, persistent index handles)
+    Serve {
+        /// HTTP port to listen on
+        #[arg(long, default_value = "8020")]
+        port: u16,
+        /// Host address to bind to (localhost only by default)
+        #[arg(long, default_value = "127.0.0.1")]
+        host: String,
+    },
     /// Initialize corvia in the current directory
     Init {
         /// Auto-accept all prompts
@@ -152,6 +161,9 @@ async fn main() {
             } else {
                 mcp::run(cli.base_dir.as_deref()).await
             }
+        }
+        Command::Serve { port, host } => {
+            mcp::serve_http(cli.base_dir.as_deref(), &host, port).await
         }
         Command::Init { yes, force, model_path, format } => {
             cmd_init(cli.base_dir, yes, force, model_path, format)

--- a/crates/corvia-cli/src/mcp.rs
+++ b/crates/corvia-cli/src/mcp.rs
@@ -606,54 +606,61 @@ async fn handle_tools_call_http(
             "corvia_search" => {
                 let p: SearchToolParams = serde_json::from_value(args)
                     .map_err(|e| anyhow::anyhow!("invalid search params: {e}"))?;
-                let redb = &state.handles.redb;
-                let tantivy = &state.handles.tantivy;
                 let kind = match &p.kind {
                     Some(k) => Some(k.parse::<Kind>().map_err(|e| anyhow::anyhow!(e))?),
                     None => None,
                 };
-                corvia_core::search::search_with_handles(
-                    &state.config,
-                    &state.base_dir,
-                    &state.embedder,
-                    &SearchParams {
-                        query: p.query,
-                        limit: p.limit,
-                        max_tokens: p.max_tokens,
-                        min_score: p.min_score,
-                        kind,
-                    },
-                    redb,
-                    tantivy,
-                )
-                .and_then(|r| {
-                    serde_json::to_value(&r)
-                        .map_err(|e| anyhow::anyhow!("serializing search response: {e}"))
+                let search_params = SearchParams {
+                    query: p.query,
+                    limit: p.limit,
+                    max_tokens: p.max_tokens,
+                    min_score: p.min_score,
+                    kind,
+                };
+                // search_with_handles is CPU-bound (embedding + reranker inference).
+                // Use block_in_place so we don't block the tokio worker thread.
+                tokio::task::block_in_place(|| {
+                    corvia_core::search::search_with_handles(
+                        &state.config,
+                        &state.base_dir,
+                        &state.embedder,
+                        &search_params,
+                        &state.handles.redb,
+                        &state.handles.tantivy,
+                    )
+                    .and_then(|r| {
+                        serde_json::to_value(&r)
+                            .map_err(|e| anyhow::anyhow!("serializing search response: {e}"))
+                    })
                 })
             }
             "corvia_write" => {
                 let p: WriteToolParams = serde_json::from_value(args)
                     .map_err(|e| anyhow::anyhow!("invalid write params: {e}"))?;
                 let kind = p.kind.parse::<Kind>().map_err(|e| anyhow::anyhow!(e))?;
+                let write_params = corvia_core::write::WriteParams {
+                    content: p.content,
+                    kind,
+                    tags: p.tags,
+                    supersedes: p.supersedes,
+                };
+                // Acquire write lock (async) before the blocking work.
                 let _lock = state.handles.write_lock.lock().await;
-                let redb = &state.handles.redb;
-                let tantivy = &state.handles.tantivy;
-                corvia_core::write::write_with_handles(
-                    &state.config,
-                    &state.base_dir,
-                    &state.embedder,
-                    corvia_core::write::WriteParams {
-                        content: p.content,
-                        kind,
-                        tags: p.tags,
-                        supersedes: p.supersedes,
-                    },
-                    redb,
-                    tantivy,
-                )
-                .and_then(|r| {
-                    serde_json::to_value(&r)
-                        .map_err(|e| anyhow::anyhow!("serializing write response: {e}"))
+                // write_with_handles is CPU-bound (embedding) + blocking I/O (redb, tantivy).
+                // Use block_in_place so we don't block the tokio worker thread.
+                tokio::task::block_in_place(|| {
+                    corvia_core::write::write_with_handles(
+                        &state.config,
+                        &state.base_dir,
+                        &state.embedder,
+                        write_params,
+                        &state.handles.redb,
+                        &state.handles.tantivy,
+                    )
+                    .and_then(|r| {
+                        serde_json::to_value(&r)
+                            .map_err(|e| anyhow::anyhow!("serializing write response: {e}"))
+                    })
                 })
             }
             "corvia_status" => handle_status_with_handles(
@@ -679,8 +686,9 @@ async fn handle_tools_call_http(
         Ok(value) => Ok(serde_json::json!({
             "content": [{ "type": "text", "text": value.to_string() }]
         })),
+        // Use {e} (not {e:#}) to avoid leaking internal filesystem paths in error chains.
         Err(e) => Ok(serde_json::json!({
-            "content": [{ "type": "text", "text": format!("Error: {e:#}") }],
+            "content": [{ "type": "text", "text": format!("Error: {e}") }],
             "isError": true,
         })),
     }
@@ -696,7 +704,11 @@ fn is_notification_request(req: &serde_json::Value) -> bool {
             .unwrap_or(false)
 }
 
-/// Axum handler for POST /mcp — MCP Streamable HTTP transport (2025-06-18 spec).
+/// Axum handler for POST /mcp — MCP Streamable HTTP transport.
+///
+/// Implements the single-endpoint POST pattern from the MCP spec.
+/// The `protocolVersion` in the initialize response is `"2024-11-05"` (the version
+/// of the MCP protocol, distinct from the Streamable HTTP transport spec revision).
 async fn mcp_post_handler(
     State(state): State<ServeState>,
     Json(req): Json<serde_json::Value>,
@@ -797,11 +809,23 @@ pub async fn serve_http(base_dir_arg: Option<&std::path::Path>, host: &str, port
         .layer(axum::extract::DefaultBodyLimit::max(1024 * 1024))
         .with_state(state);
 
+    // Security note: no authentication is implemented (by design for localhost-only use).
+    // If binding to a non-loopback address, warn explicitly.
+    let is_loopback = host == "127.0.0.1" || host == "::1" || host == "localhost";
+    if !is_loopback {
+        eprintln!(
+            "WARNING: corvia serve is binding to {host} (not localhost). \
+             The MCP server has no authentication — any client on this network \
+             can read and write the knowledge store."
+        );
+    }
+
     let addr = format!("{host}:{port}");
     let listener = tokio::net::TcpListener::bind(&addr)
         .await
         .with_context(|| format!("binding to {addr}"))?;
 
+    eprintln!("corvia HTTP MCP server ready at http://{addr}/mcp");
     info!("corvia HTTP MCP server listening on http://{addr}/mcp");
 
     axum::serve(listener, app)

--- a/crates/corvia-cli/src/mcp.rs
+++ b/crates/corvia-cli/src/mcp.rs
@@ -585,16 +585,24 @@ async fn handle_tools_call_http(
             serde_json::json!({ "code": -32602, "message": "Missing tool name in params" })
         })?;
 
+    // Reject unknown tools before entering the anyhow context.
+    match name {
+        "corvia_search" | "corvia_write" | "corvia_status" | "corvia_traces" => {}
+        other => {
+            return Err(serde_json::json!({
+                "code": -32602,
+                "message": format!("Unknown tool: {other}"),
+            }));
+        }
+    }
+
     let args = params
         .get("arguments")
         .cloned()
         .unwrap_or(serde_json::Value::Object(Default::default()));
 
-    // Use an inner async block to capture all tool dispatch in a single
-    // anyhow::Result context, avoiding `?`-propagation type conflicts with
-    // the outer Result<_, serde_json::Value>.
     let tool_result: anyhow::Result<serde_json::Value> = async {
-        let result: anyhow::Result<serde_json::Value> = match name {
+        match name {
             "corvia_search" => {
                 let p: SearchToolParams = serde_json::from_value(args)
                     .map_err(|e| anyhow::anyhow!("invalid search params: {e}"))?;
@@ -618,7 +626,10 @@ async fn handle_tools_call_http(
                     redb,
                     tantivy,
                 )
-                .map(|r| serde_json::to_value(&r).unwrap_or_default())
+                .and_then(|r| {
+                    serde_json::to_value(&r)
+                        .map_err(|e| anyhow::anyhow!("serializing search response: {e}"))
+                })
             }
             "corvia_write" => {
                 let p: WriteToolParams = serde_json::from_value(args)
@@ -640,7 +651,10 @@ async fn handle_tools_call_http(
                     redb,
                     tantivy,
                 )
-                .map(|r| serde_json::to_value(&r).unwrap_or_default())
+                .and_then(|r| {
+                    serde_json::to_value(&r)
+                        .map_err(|e| anyhow::anyhow!("serializing write response: {e}"))
+                })
             }
             "corvia_status" => handle_status_with_handles(
                 &state.config,
@@ -656,12 +670,8 @@ async fn handle_tools_call_http(
                     });
                 handle_traces(&state.config, &state.base_dir, p)
             }
-            other => {
-                // Return a sentinel error; converted to JSON-RPC error below.
-                anyhow::bail!("__unknown_tool__:{other}");
-            }
-        };
-        result
+            _ => unreachable!("tool name validated above"),
+        }
     }
     .await;
 
@@ -669,19 +679,10 @@ async fn handle_tools_call_http(
         Ok(value) => Ok(serde_json::json!({
             "content": [{ "type": "text", "text": value.to_string() }]
         })),
-        Err(e) => {
-            let msg = e.to_string();
-            if let Some(tool_name) = msg.strip_prefix("__unknown_tool__:") {
-                return Err(serde_json::json!({
-                    "code": -32602,
-                    "message": format!("Unknown tool: {tool_name}"),
-                }));
-            }
-            Ok(serde_json::json!({
-                "content": [{ "type": "text", "text": format!("Error: {e:#}") }],
-                "isError": true,
-            }))
-        }
+        Err(e) => Ok(serde_json::json!({
+            "content": [{ "type": "text", "text": format!("Error: {e:#}") }],
+            "isError": true,
+        })),
     }
 }
 
@@ -793,6 +794,7 @@ pub async fn serve_http(base_dir_arg: Option<&std::path::Path>, host: &str, port
 
     let app = Router::new()
         .route("/mcp", post(mcp_post_handler))
+        .layer(axum::extract::DefaultBodyLimit::max(1024 * 1024))
         .with_state(state);
 
     let addr = format!("{host}:{port}");

--- a/crates/corvia-cli/src/mcp.rs
+++ b/crates/corvia-cli/src/mcp.rs
@@ -7,7 +7,15 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::post,
+    Json, Router,
+};
 use rmcp::handler::server::ServerHandler;
+use tokio::sync::Mutex as TokioMutex;
 use rmcp::model::{
     CallToolRequestParam, CallToolResult, Content, Implementation, ListToolsResult,
     PaginatedRequestParam, ServerCapabilities, ServerInfo, Tool,
@@ -95,6 +103,28 @@ impl CorviaServer {
             peer: None,
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// HTTP server state (for `corvia serve`)
+// ---------------------------------------------------------------------------
+
+/// Persistent index handles held open for the lifetime of the HTTP server.
+///
+/// `write_lock` serializes write operations (one write at a time); reads are concurrent.
+struct IndexHandles {
+    redb: RedbIndex,
+    tantivy: TantivyIndex,
+    write_lock: TokioMutex<()>,
+}
+
+/// Axum state shared across all HTTP MCP handler calls.
+#[derive(Clone)]
+struct ServeState {
+    config: Arc<Config>,
+    embedder: Arc<Embedder>,
+    base_dir: std::path::PathBuf,
+    handles: Arc<IndexHandles>,
 }
 
 // ---------------------------------------------------------------------------
@@ -455,6 +485,321 @@ impl ServerHandler for CorviaServer {
 }
 
 // ---------------------------------------------------------------------------
+// HTTP MCP helper handlers
+// ---------------------------------------------------------------------------
+
+/// MCP `initialize` response — server capabilities handshake.
+fn handle_initialize_http() -> serde_json::Value {
+    serde_json::json!({
+        "protocolVersion": "2024-11-05",
+        "capabilities": {
+            "tools": {}
+        },
+        "serverInfo": {
+            "name": "corvia",
+            "version": env!("CARGO_PKG_VERSION"),
+        }
+    })
+}
+
+/// MCP `tools/list` response — the four corvia tools.
+fn handle_tools_list_http() -> serde_json::Value {
+    let tools = vec![
+        serde_json::to_value(search_tool()).unwrap_or_default(),
+        serde_json::to_value(write_tool()).unwrap_or_default(),
+        serde_json::to_value(status_tool()).unwrap_or_default(),
+        serde_json::to_value(traces_tool()).unwrap_or_default(),
+    ];
+    serde_json::json!({ "tools": tools })
+}
+
+/// Status handler using pre-opened index handles.
+fn handle_status_with_handles(
+    config: &Config,
+    base_dir: &std::path::Path,
+    redb: &RedbIndex,
+    tantivy: &TantivyIndex,
+) -> Result<serde_json::Value> {
+    let storage_path = base_dir.join(&config.data_dir);
+
+    let entry_count = redb.entry_count().unwrap_or(0);
+    let superseded_count = redb
+        .superseded_ids()
+        .map(|ids| ids.len() as u64)
+        .unwrap_or(0);
+    let vector_count = redb.vector_count().unwrap_or(0);
+    let last_ingest = redb.get_meta("last_ingest").ok().flatten();
+
+    let indexed_count_str = redb.get_meta("entry_count").ok().flatten();
+    let indexed_count: u64 = indexed_count_str
+        .as_deref()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let entries_dir = base_dir.join(config.entries_dir());
+    let actual_count = corvia_core::entry::scan_entries(&entries_dir)
+        .map(|v| v.len() as u64)
+        .unwrap_or(0);
+    let stale = actual_count != indexed_count;
+
+    let bm25_docs = tantivy.doc_count();
+
+    let trace_path = base_dir.join(&config.data_dir).join("traces.jsonl");
+    let parsed_traces = corvia_core::trace::read_recent_traces(&trace_path, 10);
+    let recent_traces: Vec<corvia_core::types::TraceEntry> = parsed_traces
+        .into_iter()
+        .map(|t| corvia_core::types::TraceEntry {
+            name: t.name,
+            elapsed_ms: t.elapsed_ms,
+            timestamp_ns: t.timestamp_ns,
+            attributes: t.attributes,
+        })
+        .collect();
+
+    let response = corvia_core::types::StatusResponse {
+        entry_count,
+        superseded_count,
+        index_health: corvia_core::types::IndexHealth {
+            bm25_docs,
+            vector_count,
+            last_ingest,
+            stale,
+        },
+        storage_path: storage_path.display().to_string(),
+        recent_traces,
+    };
+
+    Ok(serde_json::to_value(&response)?)
+}
+
+/// Route a `tools/call` request to the appropriate handler.
+///
+/// Returns `Ok(content_value)` on success or `Err(jsonrpc_error_object)` on failure.
+async fn handle_tools_call_http(
+    state: &ServeState,
+    params: serde_json::Value,
+) -> Result<serde_json::Value, serde_json::Value> {
+    let name = params
+        .get("name")
+        .and_then(|n| n.as_str())
+        .ok_or_else(|| {
+            serde_json::json!({ "code": -32602, "message": "Missing tool name in params" })
+        })?;
+
+    let args = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or(serde_json::Value::Object(Default::default()));
+
+    // Use an inner async block to capture all tool dispatch in a single
+    // anyhow::Result context, avoiding `?`-propagation type conflicts with
+    // the outer Result<_, serde_json::Value>.
+    let tool_result: anyhow::Result<serde_json::Value> = async {
+        let result: anyhow::Result<serde_json::Value> = match name {
+            "corvia_search" => {
+                let p: SearchToolParams = serde_json::from_value(args)
+                    .map_err(|e| anyhow::anyhow!("invalid search params: {e}"))?;
+                let redb = &state.handles.redb;
+                let tantivy = &state.handles.tantivy;
+                let kind = match &p.kind {
+                    Some(k) => Some(k.parse::<Kind>().map_err(|e| anyhow::anyhow!(e))?),
+                    None => None,
+                };
+                corvia_core::search::search_with_handles(
+                    &state.config,
+                    &state.base_dir,
+                    &state.embedder,
+                    &SearchParams {
+                        query: p.query,
+                        limit: p.limit,
+                        max_tokens: p.max_tokens,
+                        min_score: p.min_score,
+                        kind,
+                    },
+                    redb,
+                    tantivy,
+                )
+                .map(|r| serde_json::to_value(&r).unwrap_or_default())
+            }
+            "corvia_write" => {
+                let p: WriteToolParams = serde_json::from_value(args)
+                    .map_err(|e| anyhow::anyhow!("invalid write params: {e}"))?;
+                let kind = p.kind.parse::<Kind>().map_err(|e| anyhow::anyhow!(e))?;
+                let _lock = state.handles.write_lock.lock().await;
+                let redb = &state.handles.redb;
+                let tantivy = &state.handles.tantivy;
+                corvia_core::write::write_with_handles(
+                    &state.config,
+                    &state.base_dir,
+                    &state.embedder,
+                    corvia_core::write::WriteParams {
+                        content: p.content,
+                        kind,
+                        tags: p.tags,
+                        supersedes: p.supersedes,
+                    },
+                    redb,
+                    tantivy,
+                )
+                .map(|r| serde_json::to_value(&r).unwrap_or_default())
+            }
+            "corvia_status" => handle_status_with_handles(
+                &state.config,
+                &state.base_dir,
+                &state.handles.redb,
+                &state.handles.tantivy,
+            ),
+            "corvia_traces" => {
+                let p: TracesToolParams =
+                    serde_json::from_value(args).unwrap_or(TracesToolParams {
+                        limit: 10,
+                        span_filter: None,
+                    });
+                handle_traces(&state.config, &state.base_dir, p)
+            }
+            other => {
+                // Return a sentinel error; converted to JSON-RPC error below.
+                anyhow::bail!("__unknown_tool__:{other}");
+            }
+        };
+        result
+    }
+    .await;
+
+    match tool_result {
+        Ok(value) => Ok(serde_json::json!({
+            "content": [{ "type": "text", "text": value.to_string() }]
+        })),
+        Err(e) => {
+            let msg = e.to_string();
+            if let Some(tool_name) = msg.strip_prefix("__unknown_tool__:") {
+                return Err(serde_json::json!({
+                    "code": -32602,
+                    "message": format!("Unknown tool: {tool_name}"),
+                }));
+            }
+            Ok(serde_json::json!({
+                "content": [{ "type": "text", "text": format!("Error: {e:#}") }],
+                "isError": true,
+            }))
+        }
+    }
+}
+
+/// Axum handler for POST /mcp — MCP Streamable HTTP transport (2025-06-18 spec).
+async fn mcp_post_handler(
+    State(state): State<ServeState>,
+    Json(req): Json<serde_json::Value>,
+) -> Response {
+    let id = req.get("id").cloned();
+    let method = req.get("method").and_then(|m| m.as_str()).unwrap_or("");
+    let params = req
+        .get("params")
+        .cloned()
+        .unwrap_or(serde_json::Value::Object(Default::default()));
+
+    // Notifications have no id and expect no response body.
+    if id.is_none() && method.starts_with("notifications/") {
+        return StatusCode::ACCEPTED.into_response();
+    }
+
+    let result = match method {
+        "initialize" => Ok(handle_initialize_http()),
+        "tools/list" => Ok(handle_tools_list_http()),
+        "tools/call" => handle_tools_call_http(&state, params).await,
+        "ping" => Ok(serde_json::json!({})),
+        _ => Err(serde_json::json!({
+            "code": -32601,
+            "message": format!("Method not found: {method}"),
+        })),
+    };
+
+    match result {
+        Ok(value) => Json(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": value,
+        }))
+        .into_response(),
+        Err(err_obj) => Json(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": err_obj,
+        }))
+        .into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point for HTTP MCP server
+// ---------------------------------------------------------------------------
+
+/// Start the HTTP MCP server. Called from `main.rs` when `corvia serve` is invoked.
+///
+/// Opens RedbIndex and TantivyIndex once at startup and holds them open for the
+/// lifetime of the process. Multiple concurrent clients can connect; reads are
+/// fully concurrent, writes are serialized via a tokio Mutex.
+pub async fn serve_http(base_dir_arg: Option<&std::path::Path>, host: &str, port: u16) -> Result<()> {
+    let base_dir = corvia_core::discover::resolve_base_dir(base_dir_arg)?;
+    let config = Config::load_discovered(&base_dir).context("loading config")?;
+
+    // Ensure required directories exist (handles fresh installs before first ingest).
+    let index_dir = base_dir.join(config.index_dir());
+    let entries_dir = base_dir.join(config.entries_dir());
+    std::fs::create_dir_all(&index_dir)
+        .with_context(|| format!("creating index dir: {}", index_dir.display()))?;
+    std::fs::create_dir_all(&entries_dir)
+        .with_context(|| format!("creating entries dir: {}", entries_dir.display()))?;
+
+    // Open index handles once.
+    info!("opening index handles");
+    let redb = RedbIndex::open(&base_dir.join(config.redb_path()))
+        .context("opening redb index")?;
+    let tantivy_index = TantivyIndex::open(&base_dir.join(config.tantivy_dir()))
+        .context("opening tantivy index")?;
+
+    // Create embedder once (model loading is expensive).
+    info!("initializing embedder (this may download models on first run)");
+    let cache_dir = config.embedding.model_path.clone();
+    let embedder = Embedder::new(
+        cache_dir.as_deref(),
+        &config.embedding.model,
+        &config.embedding.reranker_model,
+    )
+    .context("initializing embedder")?;
+    info!("embedder ready");
+
+    let handles = Arc::new(IndexHandles {
+        redb,
+        tantivy: tantivy_index,
+        write_lock: TokioMutex::new(()),
+    });
+
+    let state = ServeState {
+        config: Arc::new(config),
+        embedder: Arc::new(embedder),
+        base_dir,
+        handles,
+    };
+
+    let app = Router::new()
+        .route("/mcp", post(mcp_post_handler))
+        .with_state(state);
+
+    let addr = format!("{host}:{port}");
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .with_context(|| format!("binding to {addr}"))?;
+
+    info!("corvia HTTP MCP server listening on http://{addr}/mcp");
+
+    axum::serve(listener, app)
+        .await
+        .context("HTTP server error")?;
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Public entry point
 // ---------------------------------------------------------------------------
 
@@ -540,4 +885,46 @@ pub async fn run_test(base_dir_arg: Option<&Path>) -> Result<()> {
 
     println!("  status:     ready");
     Ok(())
+}
+
+#[cfg(test)]
+mod http_tests {
+    use super::*;
+
+    #[test]
+    fn initialize_response_has_required_fields() {
+        let resp = handle_initialize_http();
+        assert!(resp.get("protocolVersion").is_some(), "missing protocolVersion");
+        assert!(resp.get("capabilities").is_some(), "missing capabilities");
+        assert!(resp.get("serverInfo").is_some(), "missing serverInfo");
+        let caps = resp["capabilities"].as_object().unwrap();
+        assert!(caps.contains_key("tools"), "capabilities missing tools");
+    }
+
+    #[test]
+    fn tools_list_response_has_four_tools() {
+        let resp = handle_tools_list_http();
+        let tools = resp["tools"].as_array().expect("tools should be an array");
+        assert_eq!(tools.len(), 4, "expected 4 tools");
+        let names: Vec<&str> = tools
+            .iter()
+            .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
+            .collect();
+        assert!(names.contains(&"corvia_search"));
+        assert!(names.contains(&"corvia_write"));
+        assert!(names.contains(&"corvia_status"));
+        assert!(names.contains(&"corvia_traces"));
+    }
+
+    #[test]
+    fn notification_has_no_id_field() {
+        // Notifications: the client sends messages without an "id".
+        // We verify our parsing logic correctly identifies them.
+        let msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+            "params": {}
+        });
+        assert!(msg.get("id").is_none(), "notifications must not have id");
+    }
 }

--- a/crates/corvia-cli/src/mcp.rs
+++ b/crates/corvia-cli/src/mcp.rs
@@ -685,6 +685,16 @@ async fn handle_tools_call_http(
     }
 }
 
+/// Returns true if the JSON-RPC request is a notification (no "id") targeting a notifications/ method.
+fn is_notification_request(req: &serde_json::Value) -> bool {
+    req.get("id").is_none()
+        && req
+            .get("method")
+            .and_then(|m| m.as_str())
+            .map(|m| m.starts_with("notifications/"))
+            .unwrap_or(false)
+}
+
 /// Axum handler for POST /mcp — MCP Streamable HTTP transport (2025-06-18 spec).
 async fn mcp_post_handler(
     State(state): State<ServeState>,
@@ -698,7 +708,7 @@ async fn mcp_post_handler(
         .unwrap_or(serde_json::Value::Object(Default::default()));
 
     // Notifications have no id and expect no response body.
-    if id.is_none() && method.starts_with("notifications/") {
+    if is_notification_request(&req) {
         return StatusCode::ACCEPTED.into_response();
     }
 
@@ -917,14 +927,39 @@ mod http_tests {
     }
 
     #[test]
-    fn notification_has_no_id_field() {
-        // Notifications: the client sends messages without an "id".
-        // We verify our parsing logic correctly identifies them.
-        let msg = serde_json::json!({
+    fn notification_detection_identifies_notifications_correctly() {
+        // Verify the notification detection helper correctly identifies notification requests.
+        let notification = serde_json::json!({
             "jsonrpc": "2.0",
             "method": "notifications/initialized",
             "params": {}
         });
-        assert!(msg.get("id").is_none(), "notifications must not have id");
+        assert!(
+            is_notification_request(&notification),
+            "notifications/initialized without id should be identified as notification"
+        );
+
+        // Regular requests with an id are NOT notifications.
+        let regular_request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "notifications/initialized",
+            "params": {}
+        });
+        assert!(
+            !is_notification_request(&regular_request),
+            "request with id should not be identified as notification"
+        );
+
+        // Non-notifications/ methods without id are also NOT notifications.
+        let non_notification = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "params": {}
+        });
+        assert!(
+            !is_notification_request(&non_notification),
+            "initialize without id should not be identified as notification"
+        );
     }
 }

--- a/crates/corvia-core/src/search.rs
+++ b/crates/corvia-core/src/search.rs
@@ -170,41 +170,25 @@ fn deduplicate_by_entry(candidates: &mut Vec<(String, String, f32)>) {
 // Main search function
 // ---------------------------------------------------------------------------
 
-/// Run the hybrid search pipeline.
+/// Run the hybrid search pipeline with pre-opened index handles.
 ///
-/// Steps:
-/// 1. Open RedbIndex and TantivyIndex
-/// 2. Cold start check (no entries indexed)
-/// 3. Drift detection (entry_count vs actual files)
-/// 4. Oversample if kind filter is set
-/// 5. BM25 search via tantivy
-/// 6. Vector search via redb + cosine similarity
-/// 7. RRF fusion
-/// 8. Sort by fused score, take top reranker_candidates
-/// 9. Cross-encoder rerank
-/// 10. Apply min_score filter
-/// 11. Apply max_tokens budget
-/// 12. Build SearchResult for each
-/// 13. Compute quality signal
-#[tracing::instrument(name = "corvia.search", skip(config, base_dir, embedder, params), fields(
+/// Use this when the caller holds persistent index handles (e.g. the HTTP MCP server).
+/// For one-shot callers, use [`search`] which opens handles internally.
+#[tracing::instrument(name = "corvia.search", skip(config, base_dir, embedder, params, redb, tantivy), fields(
     query_len = params.query.len(),
     limit = params.limit,
     kind_filter = ?params.kind,
     result_count = tracing::field::Empty,
     confidence = tracing::field::Empty,
 ))]
-pub fn search(
+pub fn search_with_handles(
     config: &Config,
     base_dir: &Path,
     embedder: &Embedder,
     params: &SearchParams,
+    redb: &RedbIndex,
+    tantivy: &TantivyIndex,
 ) -> Result<SearchResponse> {
-    // Step 1: Open indexes.
-    let redb = RedbIndex::open(&base_dir.join(config.redb_path()))
-        .context("opening redb index for search")?;
-    let tantivy = TantivyIndex::open(&base_dir.join(config.tantivy_dir()))
-        .context("opening tantivy index for search")?;
-
     // Step 2: Cold start check.
     let indexed_count_str = redb
         .get_meta("entry_count")
@@ -247,7 +231,6 @@ pub fn search(
     } else {
         params.limit
     };
-    // Use at least reranker_candidates for retrieval to feed the reranker.
     let retrieval_limit = retrieval_limit.max(config.search.reranker_candidates);
 
     // Step 5: BM25 search.
@@ -274,18 +257,13 @@ pub fn search(
 
         let mut scored: Vec<(String, String, f32)> = Vec::new();
         for (chunk_id, vector) in &all_vectors {
-            // Look up entry_id for this chunk.
             let entry_id = match redb.chunk_entry_id(chunk_id)? {
                 Some(eid) => eid,
                 None => continue,
             };
-
-            // Skip superseded entries.
             if superseded_ids.contains(&entry_id) {
                 continue;
             }
-
-            // Apply kind filter at the vector search level if set.
             if let Some(ref kind_filter) = params.kind {
                 if let Ok(Some(chunk_kind_str)) = redb.get_chunk_kind(chunk_id) {
                     if let Ok(chunk_kind) = chunk_kind_str.parse::<Kind>() {
@@ -295,12 +273,9 @@ pub fn search(
                     }
                 }
             }
-
             let similarity = Embedder::cosine_similarity(&query_vector, vector);
             scored.push((chunk_id.clone(), entry_id, similarity));
         }
-
-        // Sort by descending similarity.
         scored.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
         scored.truncate(retrieval_limit);
         Span::current().record("result_count", scored.len());
@@ -317,7 +292,7 @@ pub fn search(
         result
     };
 
-    // Step 8: Sort by fused score, take top reranker_candidates.
+    // Step 8: Take top reranker_candidates.
     let reranker_count = config.search.reranker_candidates.min(fused.len());
     let top_candidates = &fused[..reranker_count];
 
@@ -325,7 +300,6 @@ pub fn search(
     let mut scored_results = {
         let _span = info_span!("corvia.search.rerank", input_count = top_candidates.len(), output_count = tracing::field::Empty).entered();
 
-        // Retrieve chunk text for each candidate from tantivy.
         let mut candidate_texts: Vec<String> = Vec::with_capacity(top_candidates.len());
         let mut candidate_chunk_ids: Vec<String> = Vec::with_capacity(top_candidates.len());
         let mut candidate_entry_ids: Vec<String> = Vec::with_capacity(top_candidates.len());
@@ -346,7 +320,6 @@ pub fn search(
             }
         }
 
-        // Build scored results: (chunk_id, entry_id, score, text).
         let mut results: Vec<(String, String, f32, String)>;
 
         if candidate_texts.is_empty() {
@@ -371,7 +344,6 @@ pub fn search(
                     }
                 }
                 Err(e) => {
-                    // If reranking fails, fall back to RRF scores.
                     warn!(error = %e, "reranker failed, falling back to RRF scores");
                     results = candidate_chunk_ids
                         .iter()
@@ -395,20 +367,18 @@ pub fn search(
         results
     };
 
-    // Deduplicate by entry_id (keep highest-scoring chunk per entry).
+    // Deduplicate by entry_id.
     {
         let mut dedup_input: Vec<(String, String, f32)> = scored_results
             .iter()
             .map(|(cid, eid, score, _)| (cid.clone(), eid.clone(), *score))
             .collect();
         deduplicate_by_entry(&mut dedup_input);
-
         let keep_chunks: std::collections::HashSet<String> =
             dedup_input.iter().map(|(cid, _, _)| cid.clone()).collect();
         scored_results.retain(|(cid, _, _, _)| keep_chunks.contains(cid));
     }
 
-    // Sort by score descending after dedup.
     scored_results.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
 
     // Step 10: Apply min_score filter.
@@ -418,9 +388,6 @@ pub fn search(
     }
 
     // Step 11: Apply max_tokens budget.
-    // Token estimation: multiply word count by 1.33 to approximate subword tokens.
-    // English text averages ~1.33 tokens per whitespace-delimited word due to
-    // subword tokenization (e.g., "programming" -> "program" + "ming").
     if let Some(budget) = params.max_tokens {
         let mut token_count = 0usize;
         let mut keep_count = 0usize;
@@ -436,7 +403,6 @@ pub fn search(
         scored_results.truncate(keep_count);
     }
 
-    // Truncate to requested limit.
     scored_results.truncate(params.limit);
 
     // Step 12: Build SearchResult for each.
@@ -444,13 +410,11 @@ pub fn search(
 
     let mut results: Vec<SearchResult> = Vec::with_capacity(scored_results.len());
     for (chunk_id, entry_id, score, content) in scored_results {
-        // Look up kind from tantivy stored field.
         let kind = tantivy
             .get_chunk_kind(&chunk_id)
             .ok()
             .flatten()
             .unwrap_or_default();
-
         results.push(SearchResult {
             id: entry_id,
             kind,
@@ -463,19 +427,15 @@ pub fn search(
     let quality = {
         let _span = info_span!("corvia.search.quality", confidence = tracing::field::Empty, stale).entered();
         let mut q = compute_quality_signal(&final_scores, stale);
-
-        // Provide a suggestion when min_score filtering removed all candidates.
         if results.is_empty() && pre_min_score_count > 0 && params.min_score.is_some() {
             q.suggestion = Some(
                 "No results above minimum score threshold. Try lowering min_score or broadening your query.".to_string(),
             );
         }
-
         Span::current().record("confidence", tracing::field::debug(q.confidence));
         q
     };
 
-    // Record final metrics on the parent span.
     Span::current().record("result_count", results.len());
     Span::current().record("confidence", tracing::field::debug(quality.confidence));
 
@@ -486,6 +446,22 @@ pub fn search(
     );
 
     Ok(SearchResponse { results, quality })
+}
+
+/// Run the hybrid search pipeline, opening index handles internally.
+///
+/// For callers that hold persistent handles, use [`search_with_handles`] directly.
+pub fn search(
+    config: &Config,
+    base_dir: &Path,
+    embedder: &Embedder,
+    params: &SearchParams,
+) -> Result<SearchResponse> {
+    let redb = RedbIndex::open(&base_dir.join(config.redb_path()))
+        .context("opening redb index for search")?;
+    let tantivy = TantivyIndex::open(&base_dir.join(config.tantivy_dir()))
+        .context("opening tantivy index for search")?;
+    search_with_handles(config, base_dir, embedder, params, &redb, &tantivy)
 }
 
 // ---------------------------------------------------------------------------
@@ -656,5 +632,19 @@ mod tests {
                 .unwrap()
                 .contains("No entries indexed"),
         );
+    }
+
+    #[test]
+    fn search_with_handles_signature_exists() {
+        // Compile-time check: verify search_with_handles is public with the right signature.
+        let _fn: fn(
+            &Config,
+            &std::path::Path,
+            &crate::embed::Embedder,
+            &SearchParams,
+            &crate::index::RedbIndex,
+            &crate::tantivy_index::TantivyIndex,
+        ) -> anyhow::Result<crate::types::SearchResponse> = search_with_handles;
+        let _ = _fn;
     }
 }

--- a/crates/corvia-core/src/write.rs
+++ b/crates/corvia-core/src/write.rs
@@ -140,40 +140,25 @@ fn validate_supersedes(redb: &RedbIndex, supersedes: &[String]) -> Result<Option
 // Write pipeline
 // ---------------------------------------------------------------------------
 
-/// Write a new knowledge entry with auto-dedup detection.
+/// Write a new knowledge entry using pre-opened index handles.
 ///
-/// This is the primary write path for creating knowledge entries. It handles:
-/// - Automatic near-duplicate detection via cosine similarity
-/// - Explicit supersession when the caller provides `supersedes` IDs
-/// - Atomic file writes
-/// - Index updates (Redb vectors + Tantivy BM25)
-/// - Entry count metadata updates
-#[tracing::instrument(name = "corvia.write", skip(config, base_dir, embedder, params), fields(
+/// Callers must ensure the entries directory and index directory already exist.
+/// For one-shot callers, use [`write`] which creates directories and opens handles.
+#[tracing::instrument(name = "corvia.write", skip(config, base_dir, embedder, params, redb, tantivy), fields(
     kind = %params.kind,
     content_len = params.content.len(),
     action = tracing::field::Empty,
     superseded_count = tracing::field::Empty,
 ))]
-pub fn write(
+pub fn write_with_handles(
     config: &Config,
     base_dir: &Path,
     embedder: &Embedder,
     params: WriteParams,
+    redb: &RedbIndex,
+    tantivy: &TantivyIndex,
 ) -> Result<WriteResponse> {
-    // Step 1: Resolve paths and ensure directories exist.
     let entries_dir = base_dir.join(config.entries_dir());
-    let index_dir = base_dir.join(config.index_dir());
-
-    std::fs::create_dir_all(&entries_dir)
-        .with_context(|| format!("creating entries dir: {}", entries_dir.display()))?;
-    std::fs::create_dir_all(&index_dir)
-        .with_context(|| format!("creating index dir: {}", index_dir.display()))?;
-
-    // Step 2: Open indexes.
-    let redb =
-        RedbIndex::open(&base_dir.join(config.redb_path())).context("opening redb index")?;
-    let tantivy =
-        TantivyIndex::open(&base_dir.join(config.tantivy_dir())).context("opening tantivy index")?;
 
     // Step 3: Determine supersedes list and action.
     let caller_provided_supersedes = !params.supersedes.is_empty();
@@ -182,14 +167,13 @@ pub fn write(
     let mut dedup_similarity: Option<f32> = None;
 
     if !caller_provided_supersedes && !params.content.is_empty() {
-        // Auto-dedup: check for near-duplicate content.
         let _dedup_span = info_span!("corvia.write.dedup",
             threshold = config.search.dedup_threshold,
             matched = tracing::field::Empty,
             similarity = tracing::field::Empty,
         ).entered();
 
-        let dedup = auto_dedup_check(embedder, &redb, &params.content, config.search.dedup_threshold)
+        let dedup = auto_dedup_check(embedder, redb, &params.content, config.search.dedup_threshold)
             .context("auto-dedup check")?;
 
         if let Some(matched_id) = dedup.matched_id {
@@ -216,7 +200,7 @@ pub fn write(
     }
 
     // Step 4: Validate supersedes references.
-    let warning = validate_supersedes(&redb, &supersedes)?;
+    let warning = validate_supersedes(redb, &supersedes)?;
     if let Some(ref w) = warning {
         warn!("{}", w);
     }
@@ -236,7 +220,7 @@ pub fn write(
     info!(id = %entry_id, action = %action, "entry written to disk");
 
     // Step 6: Update indexes.
-    // 6a: Mark all superseded entries in Redb.
+    // 6a: Mark superseded entries in Redb.
     for sup_id in &supersedes {
         redb.set_superseded(sup_id, true)
             .with_context(|| format!("marking {} as superseded", sup_id))?;
@@ -246,7 +230,7 @@ pub fn write(
     redb.set_superseded(&entry_id, false)
         .with_context(|| format!("marking {} as current", entry_id))?;
 
-    // 6b2: Delete superseded entries from Tantivy so they are invisible in BM25 search.
+    // 6b2: Delete superseded entries from Tantivy.
     {
         let mut sup_writer = tantivy.writer().context("creating tantivy writer for supersession cleanup")?;
         for sup_id in &supersedes {
@@ -274,21 +258,16 @@ pub fn write(
 
         for chunk in &chunks {
             let chunk_id = format!("{}:{}", entry_id, chunk.chunk_index);
-
-            // Skip embedding if chunk text is empty.
             if chunk.text.is_empty() {
                 continue;
             }
-
             let vector = embedder
                 .embed(&chunk.text)
                 .with_context(|| format!("embedding chunk {}", chunk_id))?;
-
             redb.put_vector(&chunk_id, &entry_id, &vector)
                 .with_context(|| format!("storing vector for {}", chunk_id))?;
             redb.put_chunk_kind(&chunk_id, &chunk.kind.to_string())
                 .with_context(|| format!("storing kind for {}", chunk_id))?;
-
             tantivy
                 .add_doc(
                     &writer,
@@ -296,7 +275,7 @@ pub fn write(
                     &entry_id,
                     &chunk.text,
                     entry.meta.kind,
-                    false, // new entry is always current
+                    false,
                 )
                 .with_context(|| format!("adding tantivy doc for {}", chunk_id))?;
         }
@@ -307,14 +286,13 @@ pub fn write(
             .context("reloading tantivy reader after write")?;
     }
 
-    // Step 7: Update entry count in Redb meta (based on actual file count for consistency).
+    // Step 7: Update entry count in Redb meta.
     let actual_count = crate::entry::scan_entries(&entries_dir)
         .context("scanning entries for count update")?
         .len();
     redb.set_meta("entry_count", &actual_count.to_string())
         .context("updating entry_count metadata")?;
 
-    // Record on parent span.
     Span::current().record("action", action.as_str());
     Span::current().record("superseded_count", supersedes.len());
 
@@ -325,7 +303,6 @@ pub fn write(
         "write pipeline complete"
     );
 
-    // Step 8: Return response.
     Ok(WriteResponse {
         id: entry_id,
         action,
@@ -333,6 +310,38 @@ pub fn write(
         similarity: dedup_similarity,
         warning,
     })
+}
+
+/// Write a new knowledge entry with auto-dedup detection.
+///
+/// This is the primary write path for creating knowledge entries. It handles:
+/// - Automatic near-duplicate detection via cosine similarity
+/// - Explicit supersession when the caller provides `supersedes` IDs
+/// - Atomic file writes
+/// - Index updates (Redb vectors + Tantivy BM25)
+/// - Entry count metadata updates
+/// Write a new knowledge entry with auto-dedup detection.
+///
+/// Opens index handles internally. For callers that hold persistent handles,
+/// use [`write_with_handles`] directly.
+pub fn write(
+    config: &Config,
+    base_dir: &Path,
+    embedder: &Embedder,
+    params: WriteParams,
+) -> Result<WriteResponse> {
+    // Step 1: Resolve paths and ensure directories exist.
+    let entries_dir = base_dir.join(config.entries_dir());
+    let index_dir = base_dir.join(config.index_dir());
+    std::fs::create_dir_all(&entries_dir)
+        .with_context(|| format!("creating entries dir: {}", entries_dir.display()))?;
+    std::fs::create_dir_all(&index_dir)
+        .with_context(|| format!("creating index dir: {}", index_dir.display()))?;
+
+    // Step 2: Open indexes.
+    let redb = RedbIndex::open(&base_dir.join(config.redb_path())).context("opening redb index")?;
+    let tantivy = TantivyIndex::open(&base_dir.join(config.tantivy_dir())).context("opening tantivy index")?;
+    write_with_handles(config, base_dir, embedder, params, &redb, &tantivy)
 }
 
 // ---------------------------------------------------------------------------
@@ -556,6 +565,19 @@ mod tests {
             !redb.is_superseded(&second.id).unwrap(),
             "second entry should be current"
         );
+    }
+
+    #[test]
+    fn write_with_handles_signature_exists() {
+        let _fn: fn(
+            &crate::config::Config,
+            &std::path::Path,
+            &crate::embed::Embedder,
+            WriteParams,
+            &crate::index::RedbIndex,
+            &crate::tantivy_index::TantivyIndex,
+        ) -> anyhow::Result<crate::types::WriteResponse> = write_with_handles;
+        let _ = _fn;
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `corvia serve [--port 8020] [--host 127.0.0.1]` CLI subcommand that runs an HTTP MCP server
- Implements MCP Streamable HTTP (single POST `/mcp` endpoint) compatible with Claude Code `"type": "http"` in `.mcp.json`
- Holds `RedbIndex` + `TantivyIndex` open for the server lifetime — eliminates flock/lock contention that broke multi-client setups
- Adds `search_with_handles()` and `write_with_handles()` to corvia-core; existing `search()`/`write()` become thin wrappers (no breaking changes)
- Updates `.mcp.json` from stdio to HTTP transport
- `corvia mcp` (stdio) is unchanged and still works

## Design decisions

- **Concurrency**: reads are fully concurrent; writes serialized via `TokioMutex<()>`
- **Blocking work**: CPU-bound embedding + reranker calls wrapped in `tokio::task::block_in_place` to avoid starving the async runtime
- **No auth**: localhost-only by default; warning emitted if `--host` is a non-loopback address
- **Body limit**: 1 MiB max via `DefaultBodyLimit`
- **Transport**: manual axum handler (rmcp 0.1.5 lacks Streamable HTTP support)

## Test plan

- [x] `cargo test --workspace` — 100 tests pass (97 core + 3 http unit tests)
- [x] `corvia serve --help` shows `--port` and `--host` options
- [x] MCP initialize handshake returns correct capabilities
- [x] `tools/list` returns all 4 tools
- [x] `notifications/initialized` returns HTTP 202 with empty body
- [x] `corvia_status` and `corvia_search` tool calls succeed
- [x] Two concurrent search requests both succeed (no deadlock)
- [x] Unknown method → JSON-RPC `-32601`; unknown tool → `-32602`
- [x] Body > 1 MiB → HTTP 413
- [x] `corvia mcp` (stdio) regression test passes
- [x] `ping` → `result: {}`

## Follow-up items (out of scope)

- Auto-start `corvia serve` in devcontainer on session start
- Graceful shutdown (SIGTERM handler with drain)
- Authentication / API key support
- `GET /healthz` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)