### PR TITLE
feat(telemetry): extend corvia.search span with query, chunk IDs, per-stage scores (#123)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,6 +566,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
 ]

--- a/crates/corvia-cli/src/main.rs
+++ b/crates/corvia-cli/src/main.rs
@@ -248,7 +248,7 @@ fn cmd_search(
     let response = corvia_core::search::search(&config, &base_dir, &embedder, &params)?;
 
     for result in &response.results {
-        println!("[{:.3}] ({}) {}", result.score, result.kind, result.id);
+        println!("[{:.3}] ({}) {} (chunk: {})", result.score, result.kind, result.id, result.chunk_id);
         println!("{}", result.content);
         println!();
     }

--- a/crates/corvia-core/Cargo.toml
+++ b/crates/corvia-core/Cargo.toml
@@ -26,4 +26,8 @@ fs2 = "0.4"
 
 [dev-dependencies]
 tempfile = "3"
+# Used only by integration tests to wire a scoped OpenTelemetry subscriber
+# via tracing::subscriber::with_default (see tests/integration.rs). Production
+# integration lives in corvia-cli::telemetry. Do NOT move to [dependencies]
+# unless a non-test corvia-core code path starts using it directly.
 tracing-opentelemetry = { workspace = true }

--- a/crates/corvia-core/Cargo.toml
+++ b/crates/corvia-core/Cargo.toml
@@ -26,3 +26,4 @@ fs2 = "0.4"
 
 [dev-dependencies]
 tempfile = "3"
+tracing-opentelemetry = { workspace = true }

--- a/crates/corvia-core/src/search.rs
+++ b/crates/corvia-core/src/search.rs
@@ -54,12 +54,12 @@ fn encode_stage_scores(chunk_ids: &[String], scores: &[f32]) -> (String, String)
     (ids, sc)
 }
 
-/// Record `chunk_ids` and `scores` as JSON-string attrs on the given span.
+/// Record `chunk_ids` and `scores` as JSON-string attrs on the current span.
 /// Both fields must have been declared on the `info_span!` with `tracing::field::Empty`.
-fn record_stage_scores(span: &tracing::Span, chunk_ids: &[String], scores: &[f32]) {
+fn record_stage_scores(chunk_ids: &[String], scores: &[f32]) {
     let (ids_json, scores_json) = encode_stage_scores(chunk_ids, scores);
-    span.record("chunk_ids", ids_json.as_str());
-    span.record("scores", scores_json.as_str());
+    Span::current().record("chunk_ids", ids_json.as_str());
+    Span::current().record("scores", scores_json.as_str());
 }
 
 // ---------------------------------------------------------------------------
@@ -276,9 +276,9 @@ pub fn search_with_handles(
         Span::current().record("result_count", results.len());
 
         // Record chunk_ids + BM25 raw scores for eval mining.
-        let ids: Vec<String> = results.iter().map(|(cid, _, _)| cid.clone()).collect();
-        let scores_vec: Vec<f32> = results.iter().map(|(_, _, s)| *s).collect();
-        record_stage_scores(&Span::current(), &ids, &scores_vec);
+        let (ids, scores_vec): (Vec<String>, Vec<f32>) =
+            results.iter().map(|(cid, _, s)| (cid.clone(), *s)).unzip();
+        record_stage_scores(&ids, &scores_vec);
 
         debug!(count = results.len(), "BM25 results");
         results
@@ -328,9 +328,9 @@ pub fn search_with_handles(
         Span::current().record("result_count", scored.len());
 
         // Record chunk_ids + cosine scores for eval mining.
-        let ids: Vec<String> = scored.iter().map(|(cid, _, _)| cid.clone()).collect();
-        let scores_vec: Vec<f32> = scored.iter().map(|(_, _, s)| *s).collect();
-        record_stage_scores(&Span::current(), &ids, &scores_vec);
+        let (ids, scores_vec): (Vec<String>, Vec<f32>) =
+            scored.iter().map(|(cid, _, s)| (cid.clone(), *s)).unzip();
+        record_stage_scores(&ids, &scores_vec);
 
         debug!(count = scored.len(), "vector results");
         scored
@@ -348,10 +348,11 @@ pub fn search_with_handles(
         let result = rrf_fusion(&bm25_results, &vector_scored, config.search.rrf_k);
         Span::current().record("candidate_count", result.len());
 
-        // Record chunk_ids + RRF scores (f64 → f32) for eval mining.
-        let ids: Vec<String> = result.iter().map(|c| c.chunk_id.clone()).collect();
-        let scores_vec: Vec<f32> = result.iter().map(|c| c.rrf_score as f32).collect();
-        record_stage_scores(&Span::current(), &ids, &scores_vec);
+        // Record chunk_ids + RRF scores for eval mining.
+        // f64 → f32: RRF scores are bounded well within f32 range; truncation is intentional for telemetry only.
+        let (ids, scores_vec): (Vec<String>, Vec<f32>) =
+            result.iter().map(|c| (c.chunk_id.clone(), c.rrf_score as f32)).unzip();
+        record_stage_scores(&ids, &scores_vec);
 
         debug!(count = result.len(), "fused candidates");
         result
@@ -436,9 +437,9 @@ pub fn search_with_handles(
         }
 
         // Record chunk_ids + reranker (or RRF-fallback) scores for eval mining.
-        let ids: Vec<String> = results.iter().map(|(cid, _, _, _)| cid.clone()).collect();
-        let scores_vec: Vec<f32> = results.iter().map(|(_, _, s, _)| *s).collect();
-        record_stage_scores(&Span::current(), &ids, &scores_vec);
+        let (ids, scores_vec): (Vec<String>, Vec<f32>) =
+            results.iter().map(|(cid, _, s, _)| (cid.clone(), *s)).unzip();
+        record_stage_scores(&ids, &scores_vec);
 
         Span::current().record("output_count", results.len());
         results

--- a/crates/corvia-core/src/search.rs
+++ b/crates/corvia-core/src/search.rs
@@ -54,6 +54,14 @@ fn encode_stage_scores(chunk_ids: &[String], scores: &[f32]) -> (String, String)
     (ids, sc)
 }
 
+/// Record `chunk_ids` and `scores` as JSON-string attrs on the given span.
+/// Both fields must have been declared on the `info_span!` with `tracing::field::Empty`.
+fn record_stage_scores(span: &tracing::Span, chunk_ids: &[String], scores: &[f32]) {
+    let (ids_json, scores_json) = encode_stage_scores(chunk_ids, scores);
+    span.record("chunk_ids", ids_json.as_str());
+    span.record("scores", scores_json.as_str());
+}
+
 // ---------------------------------------------------------------------------
 // RRF fusion
 // ---------------------------------------------------------------------------
@@ -255,18 +263,37 @@ pub fn search_with_handles(
 
     // Step 5: BM25 search.
     let bm25_results = {
-        let _span = info_span!("corvia.search.bm25", query = %params.query, result_count = tracing::field::Empty).entered();
+        let _span = info_span!(
+            "corvia.search.bm25",
+            result_count = tracing::field::Empty,
+            chunk_ids = tracing::field::Empty,
+            scores = tracing::field::Empty,
+        )
+        .entered();
         let results = tantivy
             .search(&params.query, params.kind, retrieval_limit)
             .context("BM25 search")?;
         Span::current().record("result_count", results.len());
+
+        // Record chunk_ids + BM25 raw scores for eval mining.
+        let ids: Vec<String> = results.iter().map(|(cid, _, _)| cid.clone()).collect();
+        let scores: Vec<f32> = results.iter().map(|(_, _, s)| *s).collect();
+        record_stage_scores(&Span::current(), &ids, &scores);
+
         debug!(count = results.len(), "BM25 results");
         results
     };
 
     // Step 6: Vector search.
     let vector_scored = {
-        let _span = info_span!("corvia.search.vector", vector_count = tracing::field::Empty, result_count = tracing::field::Empty).entered();
+        let _span = info_span!(
+            "corvia.search.vector",
+            vector_count = tracing::field::Empty,
+            result_count = tracing::field::Empty,
+            chunk_ids = tracing::field::Empty,
+            scores = tracing::field::Empty,
+        )
+        .entered();
         let query_vector = embedder
             .embed(&params.query)
             .context("embedding search query")?;
@@ -299,15 +326,33 @@ pub fn search_with_handles(
         scored.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
         scored.truncate(retrieval_limit);
         Span::current().record("result_count", scored.len());
+
+        // Record chunk_ids + cosine scores for eval mining.
+        let ids: Vec<String> = scored.iter().map(|(cid, _, _)| cid.clone()).collect();
+        let scores_vec: Vec<f32> = scored.iter().map(|(_, _, s)| *s).collect();
+        record_stage_scores(&Span::current(), &ids, &scores_vec);
+
         debug!(count = scored.len(), "vector results");
         scored
     };
 
     // Step 7: RRF fusion.
     let fused = {
-        let _span = info_span!("corvia.search.fusion", candidate_count = tracing::field::Empty).entered();
+        let _span = info_span!(
+            "corvia.search.fusion",
+            candidate_count = tracing::field::Empty,
+            chunk_ids = tracing::field::Empty,
+            scores = tracing::field::Empty,
+        )
+        .entered();
         let result = rrf_fusion(&bm25_results, &vector_scored, config.search.rrf_k);
         Span::current().record("candidate_count", result.len());
+
+        // Record chunk_ids + RRF scores (f64 → f32) for eval mining.
+        let ids: Vec<String> = result.iter().map(|c| c.chunk_id.clone()).collect();
+        let scores_vec: Vec<f32> = result.iter().map(|c| c.rrf_score as f32).collect();
+        record_stage_scores(&Span::current(), &ids, &scores_vec);
+
         debug!(count = result.len(), "fused candidates");
         result
     };
@@ -318,7 +363,14 @@ pub fn search_with_handles(
 
     // Step 9: Cross-encoder rerank.
     let mut scored_results = {
-        let _span = info_span!("corvia.search.rerank", input_count = top_candidates.len(), output_count = tracing::field::Empty).entered();
+        let _span = info_span!(
+            "corvia.search.rerank",
+            input_count = top_candidates.len(),
+            output_count = tracing::field::Empty,
+            chunk_ids = tracing::field::Empty,
+            scores = tracing::field::Empty,
+        )
+        .entered();
 
         let mut candidate_texts: Vec<String> = Vec::with_capacity(top_candidates.len());
         let mut candidate_chunk_ids: Vec<String> = Vec::with_capacity(top_candidates.len());
@@ -382,6 +434,11 @@ pub fn search_with_handles(
                 }
             }
         }
+
+        // Record chunk_ids + reranker (or RRF-fallback) scores for eval mining.
+        let ids: Vec<String> = results.iter().map(|(cid, _, _, _)| cid.clone()).collect();
+        let rerank_scores: Vec<f32> = results.iter().map(|(_, _, s, _)| *s).collect();
+        record_stage_scores(&Span::current(), &ids, &rerank_scores);
 
         Span::current().record("output_count", results.len());
         results

--- a/crates/corvia-core/src/search.rs
+++ b/crates/corvia-core/src/search.rs
@@ -190,10 +190,12 @@ fn deduplicate_by_entry(candidates: &mut Vec<(String, String, f32)>) {
 /// Use this when the caller holds persistent index handles (e.g. the HTTP MCP server).
 /// For one-shot callers, use [`search`] which opens handles internally.
 #[tracing::instrument(name = "corvia.search", skip(config, base_dir, embedder, params, redb, tantivy), fields(
+    query = tracing::field::Empty,
     query_len = params.query.len(),
     limit = params.limit,
     kind_filter = ?params.kind,
     result_count = tracing::field::Empty,
+    result_chunk_ids = tracing::field::Empty,
     confidence = tracing::field::Empty,
 ))]
 pub fn search_with_handles(
@@ -204,6 +206,9 @@ pub fn search_with_handles(
     redb: &RedbIndex,
     tantivy: &TantivyIndex,
 ) -> Result<SearchResponse> {
+    // Record raw query for eval mining. Design RFC §4.2: no redaction toggle —
+    // corvia is single-user local; raw query is the eval join key.
+    Span::current().record("query", params.query.as_str());
     // Step 2: Cold start check.
     let indexed_count_str = redb
         .get_meta("entry_count")

--- a/crates/corvia-core/src/search.rs
+++ b/crates/corvia-core/src/search.rs
@@ -39,6 +39,21 @@ struct FusedCandidate {
     rrf_score: f64,
 }
 
+/// Encode parallel `chunk_ids` and `scores` arrays as JSON strings.
+///
+/// The OTLP file exporter serializes `opentelemetry::Value::Array` via debug
+/// formatting (`trace.rs:72`), producing strings that are not machine-parseable.
+/// Encoding as JSON strings and recording them as `stringValue` attrs lets
+/// downstream consumers parse via `json::parse` cleanly.
+///
+/// Returns `("[]", "[]")` on any (impossible-for-these-types) serde error
+/// so that attr presence is preserved even in unreachable edge cases.
+fn encode_stage_scores(chunk_ids: &[String], scores: &[f32]) -> (String, String) {
+    let ids = serde_json::to_string(chunk_ids).unwrap_or_else(|_| "[]".to_string());
+    let sc = serde_json::to_string(scores).unwrap_or_else(|_| "[]".to_string());
+    (ids, sc)
+}
+
 // ---------------------------------------------------------------------------
 // RRF fusion
 // ---------------------------------------------------------------------------
@@ -647,5 +662,30 @@ mod tests {
             &crate::tantivy_index::TantivyIndex,
         ) -> anyhow::Result<crate::types::SearchResponse> = search_with_handles;
         let _ = _fn;
+    }
+
+    #[test]
+    fn encode_stage_scores_empty() {
+        let (ids, scores) = encode_stage_scores(&[], &[]);
+        assert_eq!(ids, "[]");
+        assert_eq!(scores, "[]");
+    }
+
+    #[test]
+    fn encode_stage_scores_parallel_arrays() {
+        let chunk_ids = vec!["a:0".to_string(), "b:1".to_string(), "c:2".to_string()];
+        let scores = vec![0.9f32, 0.5, 0.1];
+        let (ids_json, scores_json) = encode_stage_scores(&chunk_ids, &scores);
+        assert_eq!(ids_json, r#"["a:0","b:1","c:2"]"#);
+        assert_eq!(scores_json, "[0.9,0.5,0.1]");
+    }
+
+    #[test]
+    fn encode_stage_scores_length_mismatch_still_encodes_both() {
+        let chunk_ids = vec!["a".to_string()];
+        let scores = vec![0.1f32, 0.2, 0.3];
+        let (ids_json, scores_json) = encode_stage_scores(&chunk_ids, &scores);
+        assert_eq!(ids_json, r#"["a"]"#);
+        assert_eq!(scores_json, "[0.1,0.2,0.3]");
     }
 }

--- a/crates/corvia-core/src/search.rs
+++ b/crates/corvia-core/src/search.rs
@@ -417,6 +417,7 @@ pub fn search_with_handles(
             .unwrap_or_default();
         results.push(SearchResult {
             id: entry_id,
+            chunk_id,
             kind,
             score,
             content,

--- a/crates/corvia-core/src/search.rs
+++ b/crates/corvia-core/src/search.rs
@@ -277,8 +277,8 @@ pub fn search_with_handles(
 
         // Record chunk_ids + BM25 raw scores for eval mining.
         let ids: Vec<String> = results.iter().map(|(cid, _, _)| cid.clone()).collect();
-        let scores: Vec<f32> = results.iter().map(|(_, _, s)| *s).collect();
-        record_stage_scores(&Span::current(), &ids, &scores);
+        let scores_vec: Vec<f32> = results.iter().map(|(_, _, s)| *s).collect();
+        record_stage_scores(&Span::current(), &ids, &scores_vec);
 
         debug!(count = results.len(), "BM25 results");
         results
@@ -437,8 +437,8 @@ pub fn search_with_handles(
 
         // Record chunk_ids + reranker (or RRF-fallback) scores for eval mining.
         let ids: Vec<String> = results.iter().map(|(cid, _, _, _)| cid.clone()).collect();
-        let rerank_scores: Vec<f32> = results.iter().map(|(_, _, s, _)| *s).collect();
-        record_stage_scores(&Span::current(), &ids, &rerank_scores);
+        let scores_vec: Vec<f32> = results.iter().map(|(_, _, s, _)| *s).collect();
+        record_stage_scores(&Span::current(), &ids, &scores_vec);
 
         Span::current().record("output_count", results.len());
         results

--- a/crates/corvia-core/src/search.rs
+++ b/crates/corvia-core/src/search.rs
@@ -798,7 +798,13 @@ mod tests {
         let scores = vec![0.9f32, 0.5, 0.1];
         let (ids_json, scores_json) = encode_stage_scores(&chunk_ids, &scores);
         assert_eq!(ids_json, r#"["a:0","b:1","c:2"]"#);
-        assert_eq!(scores_json, "[0.9,0.5,0.1]");
+        // Decode and compare with tolerance — f32 serialization is not guaranteed
+        // to produce exact decimal strings for all values.
+        let parsed_scores: Vec<f32> = serde_json::from_str(&scores_json).unwrap();
+        assert_eq!(parsed_scores.len(), 3);
+        for (got, want) in parsed_scores.iter().zip(&[0.9f32, 0.5, 0.1]) {
+            assert!((got - want).abs() < 1e-6, "score mismatch: {got} vs {want}");
+        }
     }
 
     #[test]
@@ -807,6 +813,12 @@ mod tests {
         let scores = vec![0.1f32, 0.2, 0.3];
         let (ids_json, scores_json) = encode_stage_scores(&chunk_ids, &scores);
         assert_eq!(ids_json, r#"["a"]"#);
-        assert_eq!(scores_json, "[0.1,0.2,0.3]");
+        // Decode and compare with tolerance — f32 serialization is not guaranteed
+        // to produce exact decimal strings for all values.
+        let parsed_scores: Vec<f32> = serde_json::from_str(&scores_json).unwrap();
+        assert_eq!(parsed_scores.len(), 3);
+        for (got, want) in parsed_scores.iter().zip(&[0.1f32, 0.2, 0.3]) {
+            assert!((got - want).abs() < 1e-6, "score mismatch: {got} vs {want}");
+        }
     }
 }

--- a/crates/corvia-core/src/search.rs
+++ b/crates/corvia-core/src/search.rs
@@ -49,9 +49,30 @@ struct FusedCandidate {
 /// Returns `("[]", "[]")` on any (impossible-for-these-types) serde error
 /// so that attr presence is preserved even in unreachable edge cases.
 fn encode_stage_scores(chunk_ids: &[String], scores: &[f32]) -> (String, String) {
-    let ids = serde_json::to_string(chunk_ids).unwrap_or_else(|_| "[]".to_string());
-    let sc = serde_json::to_string(scores).unwrap_or_else(|_| "[]".to_string());
+    let ids = serde_json::to_string(chunk_ids).unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "encode_stage_scores: chunk_ids serialization failed");
+        "[]".to_string()
+    });
+    let sc = serde_json::to_string(scores).unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "encode_stage_scores: scores serialization failed");
+        "[]".to_string()
+    });
     (ids, sc)
+}
+
+/// Truncate a query string to at most `max_bytes` bytes, respecting UTF-8 char boundaries.
+///
+/// Used to bound the `query` trace attribute and prevent pathological inputs from
+/// pushing the trace file past the rotation threshold.
+pub(crate) fn truncate_query(query: &str, max_bytes: usize) -> &str {
+    if query.len() <= max_bytes {
+        return query;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !query.is_char_boundary(end) {
+        end -= 1;
+    }
+    &query[..end]
 }
 
 /// Record `chunk_ids` and `scores` as JSON-string attrs on the current span.
@@ -214,9 +235,11 @@ pub fn search_with_handles(
     redb: &RedbIndex,
     tantivy: &TantivyIndex,
 ) -> Result<SearchResponse> {
-    // Record raw query for eval mining. Design RFC §4.2: no redaction toggle —
-    // corvia is single-user local; raw query is the eval join key.
-    Span::current().record("query", params.query.as_str());
+    // Record raw query for eval mining (bounded to prevent pathological inputs from
+    // pushing the trace file past rotation threshold). Design RFC §4.2: no redaction
+    // toggle — corvia is single-user local; raw query is the eval join key.
+    const MAX_QUERY_TRACE_BYTES: usize = 4096;
+    Span::current().record("query", truncate_query(&params.query, MAX_QUERY_TRACE_BYTES));
     // Step 2: Cold start check.
     let indexed_count_str = redb
         .get_meta("entry_count")
@@ -518,8 +541,10 @@ pub fn search_with_handles(
     };
 
     // Record final (post-truncation) chunk_ids for downstream eval join.
-    let result_chunk_ids_json =
-        serde_json::to_string(&final_chunk_ids).unwrap_or_else(|_| "[]".to_string());
+    let result_chunk_ids_json = serde_json::to_string(&final_chunk_ids).unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "result_chunk_ids serialization failed");
+        "[]".to_string()
+    });
     Span::current().record("result_chunk_ids", result_chunk_ids_json.as_str());
 
     Span::current().record("result_count", results.len());
@@ -732,6 +757,32 @@ mod tests {
             &crate::tantivy_index::TantivyIndex,
         ) -> anyhow::Result<crate::types::SearchResponse> = search_with_handles;
         let _ = _fn;
+    }
+
+    #[test]
+    fn records_query_truncates_large_input() {
+        // Short string — returned as-is.
+        assert_eq!(truncate_query("hello", 4096), "hello");
+
+        // Exactly at boundary — returned as-is.
+        let at_limit = "a".repeat(4096);
+        assert_eq!(truncate_query(&at_limit, 4096), at_limit);
+
+        // One byte over — truncated to 4096.
+        let over = "a".repeat(4097);
+        let truncated = truncate_query(&over, 4096);
+        assert_eq!(truncated.len(), 4096);
+
+        // Multi-byte UTF-8 char split: 4096 bytes of ASCII + a 3-byte char.
+        // The truncation must land on a char boundary (at 4096, not in the middle of the char).
+        let mut mixed = "a".repeat(4096);
+        mixed.push('€'); // U+20AC = 3 bytes (0xE2 0x82 0xAC)
+        let truncated = truncate_query(&mixed, 4096);
+        assert_eq!(truncated.len(), 4096, "should truncate at the 4096 byte boundary");
+        assert!(mixed.is_char_boundary(truncated.len()), "truncation must land on char boundary");
+
+        // Empty string.
+        assert_eq!(truncate_query("", 4096), "");
     }
 
     #[test]

--- a/crates/corvia-core/src/search.rs
+++ b/crates/corvia-core/src/search.rs
@@ -484,6 +484,8 @@ pub fn search_with_handles(
 
     // Step 12: Build SearchResult for each.
     let final_scores: Vec<f32> = scored_results.iter().map(|(_, _, s, _)| *s).collect();
+    let final_chunk_ids: Vec<String> =
+        scored_results.iter().map(|(cid, _, _, _)| cid.clone()).collect();
 
     let mut results: Vec<SearchResult> = Vec::with_capacity(scored_results.len());
     for (chunk_id, entry_id, score, content) in scored_results {
@@ -513,6 +515,11 @@ pub fn search_with_handles(
         Span::current().record("confidence", tracing::field::debug(q.confidence));
         q
     };
+
+    // Record final (post-truncation) chunk_ids for downstream eval join.
+    let result_chunk_ids_json =
+        serde_json::to_string(&final_chunk_ids).unwrap_or_else(|_| "[]".to_string());
+    Span::current().record("result_chunk_ids", result_chunk_ids_json.as_str());
 
     Span::current().record("result_count", results.len());
     Span::current().record("confidence", tracing::field::debug(quality.confidence));

--- a/crates/corvia-core/src/types.rs
+++ b/crates/corvia-core/src/types.rs
@@ -99,7 +99,10 @@ pub struct Chunk {
 /// A single search result returned by the retrieval pipeline.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchResult {
+    /// Entry ID (UUIDv7) of the source entry.
     pub id: String,
+    /// Chunk ID of the specific chunk retrieved from the entry. Format `<entry_id>:<chunk_index>`.
+    pub chunk_id: String,
     pub kind: Kind,
     pub score: f32,
     pub content: String,
@@ -265,5 +268,18 @@ mod tests {
             "empty supersedes should be skipped"
         );
         assert!(!json_empty.contains("tags"), "empty tags should be skipped");
+    }
+
+    #[test]
+    fn search_result_carries_chunk_id() {
+        let r = SearchResult {
+            id: "entry-1".to_string(),
+            chunk_id: "entry-1:3".to_string(),
+            kind: Kind::Learning,
+            score: 0.5,
+            content: "body".to_string(),
+        };
+        assert_eq!(r.chunk_id, "entry-1:3");
+        assert_eq!(r.id, "entry-1");
     }
 }

--- a/crates/corvia-core/tests/integration.rs
+++ b/crates/corvia-core/tests/integration.rs
@@ -808,7 +808,7 @@ fn search_emits_eval_telemetry_attributes() {
     let embedder = make_embedder(config);
 
     // Run search inside the subscriber scope.
-    tracing::subscriber::with_default(subscriber, || {
+    let response = tracing::subscriber::with_default(subscriber, || {
         let params = SearchParams {
             query: "why did we choose Redb".to_string(),
             limit: 5,
@@ -825,9 +825,11 @@ fn search_emits_eval_telemetry_attributes() {
             response.results.iter().all(|r| !r.chunk_id.is_empty()),
             "every SearchResult must carry a non-empty chunk_id"
         );
+        response
     });
 
-    // Flush: drop the provider to shut down and flush buffered spans.
+    // Flush: explicitly flush then drop the provider.
+    provider.force_flush().expect("flush trace provider");
     drop(provider);
 
     // Read back the trace file and locate the corvia.search root span.
@@ -893,7 +895,114 @@ fn search_emits_eval_telemetry_attributes() {
             scores.len(),
             "{stage}: chunk_ids and scores must be parallel (same length)"
         );
+        // FIX F: non-empty assertion for a successful search against the fixture corpus.
+        assert!(
+            !cids.is_empty(),
+            "{stage}: chunk_ids should be non-empty for a successful search against the fixture corpus"
+        );
     }
+
+    // FIX I: Verify span attr matches the chunk_ids returned in response.results.
+    let expected_ids: Vec<String> = response.results.iter().map(|r| r.chunk_id.clone()).collect();
+    assert_eq!(
+        ids, expected_ids,
+        "result_chunk_ids span attr must equal the chunk_ids returned in response.results"
+    );
+
+    // FIX C: Verify the pipeline used by the corvia_traces MCP tool preserves new fields.
+    use corvia_core::types::TraceEntry;
+    let trace_entries: Vec<TraceEntry> = traces
+        .iter()
+        .map(|t| TraceEntry {
+            name: t.name.clone(),
+            elapsed_ms: t.elapsed_ms,
+            timestamp_ns: t.timestamp_ns,
+            attributes: t.attributes.clone(),
+        })
+        .collect();
+    let root_entry = trace_entries
+        .iter()
+        .find(|t| t.name == "corvia.search")
+        .expect("corvia.search TraceEntry not found");
+    let serialized = serde_json::to_string(root_entry).expect("TraceEntry serializes");
+    assert!(
+        serialized.contains("\"query\""),
+        "TraceEntry JSON must preserve query attr; got: {serialized}"
+    );
+    assert!(
+        serialized.contains("\"result_chunk_ids\""),
+        "TraceEntry JSON must preserve result_chunk_ids attr; got: {serialized}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry: #123 [eval 2/7] min_score-drops-all results
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore] // requires embedding model + writes a tempfile
+fn search_with_impossible_min_score_records_empty_result_chunk_ids() {
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_sdk::trace::SdkTracerProvider;
+    use tracing_subscriber::layer::SubscriberExt;
+    use corvia_core::trace::{read_recent_traces, OtlpFileExporter};
+
+    let h = common::TestHarness::new();
+    let config = &h.config;
+    let base = h.base_dir();
+    h.copy_fixtures();
+
+    corvia_core::ingest::ingest(config, base, false).expect("ingest failed");
+
+    let trace_dir = tempfile::tempdir().unwrap();
+    let trace_path = trace_dir.path().join("traces.jsonl");
+    let file_exporter = OtlpFileExporter::new(trace_path.clone())
+        .expect("failed to create file exporter");
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(file_exporter)
+        .build();
+    let tracer = provider.tracer("corvia-test");
+    let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+    let subscriber = tracing_subscriber::registry().with(otel_layer);
+
+    let embedder = make_embedder(config);
+
+    let response = tracing::subscriber::with_default(subscriber, || {
+        let params = SearchParams {
+            query: "why did we choose Redb".to_string(),
+            limit: 5,
+            max_tokens: None,
+            min_score: Some(99.0), // impossibly high
+            kind: None,
+        };
+        search(config, base, &embedder, &params).unwrap()
+    });
+
+    assert!(
+        response.results.is_empty(),
+        "impossible min_score should yield no results"
+    );
+
+    provider.force_flush().expect("flush trace provider");
+    drop(provider);
+
+    let traces = read_recent_traces(&trace_path, 200);
+    assert!(!traces.is_empty(), "trace file should contain spans");
+
+    let root = traces
+        .iter()
+        .find(|t| t.name == "corvia.search")
+        .expect("corvia.search root span not found");
+
+    let ids_attr = root
+        .attributes
+        .get("result_chunk_ids")
+        .and_then(|v| v.as_str())
+        .expect("result_chunk_ids attr missing when min_score filters all");
+    assert_eq!(
+        ids_attr, "[]",
+        "result_chunk_ids must be \"[]\" when all results filtered by min_score"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/corvia-core/tests/integration.rs
+++ b/crates/corvia-core/tests/integration.rs
@@ -771,6 +771,132 @@ fn status_shows_correct_counts() {
 }
 
 // ---------------------------------------------------------------------------
+// Telemetry: #123 [eval 1/7]
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore] // requires embedding model + writes a tempfile
+fn search_emits_eval_telemetry_attributes() {
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_sdk::trace::SdkTracerProvider;
+    use tracing_subscriber::layer::SubscriberExt;
+    use corvia_core::trace::{read_recent_traces, OtlpFileExporter};
+
+    let h = common::TestHarness::new();
+    let config = &h.config;
+    let base = h.base_dir();
+    h.copy_fixtures();
+
+    // Ingest fixtures so the search has something to retrieve.
+    let _ingest = corvia_core::ingest::ingest(config, base, false)
+        .expect("ingest failed");
+
+    // Set up a local tracer provider pointing at a tempfile.
+    let trace_dir = tempfile::tempdir().unwrap();
+    let trace_path = trace_dir.path().join("traces.jsonl");
+    let file_exporter = OtlpFileExporter::new(trace_path.clone())
+        .expect("failed to create file exporter");
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(file_exporter)
+        .build();
+    let tracer = provider.tracer("corvia-test");
+
+    // Compose: subscriber with the otel layer so tracing spans reach the provider.
+    let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+    let subscriber = tracing_subscriber::registry().with(otel_layer);
+
+    let embedder = make_embedder(config);
+
+    // Run search inside the subscriber scope.
+    tracing::subscriber::with_default(subscriber, || {
+        let params = SearchParams {
+            query: "why did we choose Redb".to_string(),
+            limit: 5,
+            max_tokens: None,
+            min_score: None,
+            kind: None,
+        };
+        let response = search(config, base, &embedder, &params).unwrap();
+        assert!(
+            !response.results.is_empty(),
+            "search should return results from fixtures"
+        );
+        assert!(
+            response.results.iter().all(|r| !r.chunk_id.is_empty()),
+            "every SearchResult must carry a non-empty chunk_id"
+        );
+    });
+
+    // Flush: drop the provider to shut down and flush buffered spans.
+    drop(provider);
+
+    // Read back the trace file and locate the corvia.search root span.
+    let traces = read_recent_traces(&trace_path, 200);
+    assert!(
+        !traces.is_empty(),
+        "trace file should contain at least one span; path: {}",
+        trace_path.display()
+    );
+
+    let root = traces
+        .iter()
+        .find(|t| t.name == "corvia.search")
+        .expect("corvia.search root span not found in trace file");
+
+    // Root span: raw query present
+    let query_attr = root
+        .attributes
+        .get("query")
+        .and_then(|v| v.as_str())
+        .expect("corvia.search.query attr missing or wrong type");
+    assert_eq!(query_attr, "why did we choose Redb");
+
+    // Root span: result_chunk_ids is a JSON-array string
+    let ids_attr = root
+        .attributes
+        .get("result_chunk_ids")
+        .and_then(|v| v.as_str())
+        .expect("corvia.search.result_chunk_ids attr missing");
+    let ids: Vec<String> = serde_json::from_str(ids_attr)
+        .expect("result_chunk_ids must parse as JSON string array");
+    assert!(
+        !ids.is_empty(),
+        "result_chunk_ids should be non-empty for a successful search"
+    );
+    assert!(
+        ids.iter().all(|c| c.contains(':')),
+        "chunk_ids should look like '<entry>:<idx>': {ids:?}"
+    );
+
+    // Each sub-span: chunk_ids + scores present as JSON-string arrays of equal length
+    for stage in ["corvia.search.bm25", "corvia.search.vector", "corvia.search.fusion", "corvia.search.rerank"] {
+        let sub = traces
+            .iter()
+            .find(|t| t.name == stage)
+            .unwrap_or_else(|| panic!("sub-span {stage} not found"));
+        let cids_raw = sub
+            .attributes
+            .get("chunk_ids")
+            .and_then(|v| v.as_str())
+            .unwrap_or_else(|| panic!("{stage}.chunk_ids missing"));
+        let scores_raw = sub
+            .attributes
+            .get("scores")
+            .and_then(|v| v.as_str())
+            .unwrap_or_else(|| panic!("{stage}.scores missing"));
+        let cids: Vec<String> = serde_json::from_str(cids_raw)
+            .unwrap_or_else(|e| panic!("{stage}.chunk_ids bad JSON: {e}"));
+        let scores: Vec<f32> = serde_json::from_str(scores_raw)
+            .unwrap_or_else(|e| panic!("{stage}.scores bad JSON: {e}"));
+        assert_eq!(
+            cids.len(),
+            scores.len(),
+            "{stage}: chunk_ids and scores must be parallel (same length)"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // 16. full_pipeline_ordering
 // ---------------------------------------------------------------------------
 

--- a/docs/rfcs/2026-04-18-search-telemetry-extension-design.md
+++ b/docs/rfcs/2026-04-18-search-telemetry-extension-design.md
@@ -1,0 +1,203 @@
+# Search Telemetry Extension — Design
+
+**Issue:** [#123](https://github.com/chunzhe10/corvia/issues/123) [eval 1/7]
+**Parent:** #122 (RAG eval harness umbrella)
+**Author:** chunzhe10 (brainstormed with Claude Code agent)
+**Status:** Draft
+**Date:** 2026-04-18
+
+## 1. Problem
+
+The `corvia.search` span pipeline currently emits counts (`result_count`, `candidate_count`) and coarse metadata (`query_len`, `kind_filter`, `confidence`), but **loses three pieces of information that every downstream eval ticket needs**:
+
+1. Which **chunks** (not just entries) were returned — `SearchResult` drops `chunk_id` when constructed in `search.rs:418`.
+2. The **raw query text** — only `query_len` reaches the root span.
+3. The **per-stage scores** (BM25 raw, vector cosine, RRF, reranker) — computed internally and discarded.
+
+Without these, the downstream eval harness (#124–#129) cannot:
+- Join traces to an eval golden set by query.
+- Compute recall@k at chunk granularity (an entry can have many chunks; matching the right one is the recall signal).
+- Diagnose which pipeline stage caused a regression.
+
+## 2. Goals
+
+1. Add `chunk_id` to `SearchResult` as a first-class required field.
+2. Record raw `query` and final `result_chunk_ids` as attributes on the `corvia.search` root span.
+3. Record each stage's `chunk_ids` and `scores` as attributes on its sub-span (`corvia.search.bm25`, `.vector`, `.fusion`, `.rerank`).
+4. Extend the unit test suite to prove the new attrs appear in emitted traces.
+
+## 3. Non-goals
+
+- No change to retrieval logic (ranking, thresholds, reranker behavior).
+- No new telemetry backend; continue using the OTLP file exporter.
+- **No PII redaction toggle.** The issue's acceptance criterion #2 said "redactable via env flag" — during design review the threat model was re-examined and found moot: corvia is single-user, local, non-hosted; the corpus is known-safe by construction; matched-pair regression works best with raw plaintext queries as join keys. The env-flag knob is pre-building for a hypothetical hosted deployment. If that materializes, adding the toggle is a ~10-line PR. This is an intentional departure from the issue text.
+- No explicit `duration_ms` attrs per sub-span. The existing `ParsedTrace.elapsed_ms` (derived from span start/end in `trace.rs:230`) already exposes stage latency. Adding a redundant attribute is dead weight. This is also an intentional departure from the issue text.
+
+## 4. Design
+
+### 4.1 `SearchResult` struct change
+
+`crates/corvia-core/src/types.rs`:
+
+```rust
+pub struct SearchResult {
+    pub id: String,         // entry_id (unchanged name, avoid rename churn)
+    pub chunk_id: String,   // NEW: source chunk within the entry
+    pub kind: Kind,
+    pub score: f32,
+    pub content: String,
+}
+```
+
+- Plain required field, no `#[serde(default)]`, no `Option<String>`.
+- All construction sites (search.rs + tests) updated in one pass; `rustc` enforces completeness.
+- No serde backward-compat concern: corvia is pre-1.0, no external consumers of the crate, JSON is never stored-and-reread.
+- Schema change for users: index entries do not need to be re-ingested (the index stores chunk_id natively; only the user-facing API adds the field).
+
+### 4.2 Span attribute additions
+
+**Root span `corvia.search`:**
+
+| Attr | Type | Value |
+|---|---|---|
+| `query` | string | `params.query` verbatim, always |
+| `result_chunk_ids` | string | JSON array of final top-K chunk_ids after all truncation |
+
+**Sub-spans** (`bm25`, `vector`, `fusion`, `rerank`):
+
+| Attr | Type | Value |
+|---|---|---|
+| `chunk_ids` | string | JSON array of chunk_ids at this stage |
+| `scores` | string | JSON array of scores parallel to `chunk_ids` |
+
+- Each sub-span records exactly the chunks **that stage produced**, in the order it produced them. Not filtered to final top-K — stage-level regression diagnosis needs visibility into chunks that the stage saw but that a later stage dropped.
+- BM25 stage: up to `retrieval_limit` chunks (already sorted by BM25 raw score) and their scores.
+- Vector stage: up to `retrieval_limit` chunks (sorted by cosine similarity) and their cosine scores.
+- Fusion stage: all fused candidates (the union across BM25 and vector), sorted by RRF score. RRF scores are `f64` internally — cast to `f32` for the telemetry array, acceptable precision loss for diagnostic use.
+- Rerank stage: up to `reranker_candidates` chunks (sorted by reranker score). Preserves existing fallback-to-RRF path on reranker failure; the scores recorded will be whatever the code ends up using (reranker or RRF fallback).
+
+The root-span `result_chunk_ids` is the **final** top-K (after min_score/max_tokens truncation), which is the eval join key. Per-stage arrays and the final array are deliberately different: stage arrays answer "what did this stage see?"; final array answers "what did we return?"
+
+**Sub-span removal:** `corvia.search.bm25` currently records `query = %params.query`. This is redundant with the parent span's new `query` attr (join via trace ID). Remove it to avoid duplicating potentially-sensitive content.
+
+### 4.3 Encoding
+
+JSON-string encoding is forced by the OTLP file exporter (`trace.rs:72`): `opentelemetry::Value::Array` falls through to `format!("{:?}", value)` — debug-stringified, not round-trippable. By serializing arrays to JSON strings ourselves and recording as `opentelemetry::Value::String`, the exporter writes them as native `stringValue` and downstream consumers (`corvia_traces` MCP tool, Python eval harness) can `JSON.parse` them.
+
+### 4.4 Helper function (Approach II)
+
+```rust
+/// Record parallel `chunk_ids` and `scores` JSON arrays on the given span.
+///
+/// Encoding choice: the OTLP file exporter serializes `Value::Array` as a
+/// debug string, which is not machine-parseable. Encoding as a JSON string
+/// round-trips cleanly through `parse_otlp_attribute_value`.
+fn record_stage_scores(span: &Span, chunk_ids: &[String], scores: &[f32]) {
+    let ids_json = serde_json::to_string(chunk_ids).unwrap_or_else(|_| "[]".to_string());
+    let scores_json = serde_json::to_string(scores).unwrap_or_else(|_| "[]".to_string());
+    span.record("chunk_ids", ids_json.as_str());
+    span.record("scores", scores_json.as_str());
+}
+```
+
+- Lives in `search.rs` as a private function.
+- Sub-span macros must declare `chunk_ids = tracing::field::Empty, scores = tracing::field::Empty` in the `info_span!` call so `.record()` sees the fields.
+- `unwrap_or_else` returns `"[]"` on the impossible serde error; preserves attr presence so eval harness code never hits "attr missing" branches.
+
+### 4.5 Data flow in `search_with_handles`
+
+Note: the `query` attr is recorded at step 1 (before cold-start returns early), so even cold-start and zero-result searches carry the query in their trace. Sub-span attrs and `result_chunk_ids` are only written when the respective stages execute, which is correct — empty stages honestly leave the attribute absent.
+
+```
+1. Enter `corvia.search` span (instrument macro)
+   └── [NEW] Span::current().record("query", params.query.as_str())
+
+2. Cold-start check, drift detection — unchanged
+
+3. BM25 stage (existing info_span!)
+   ├── Existing: result_count
+   ├── [NEW] record_stage_scores(span, &chunk_ids_from_bm25, &bm25_scores)
+   └── [CHANGED] remove `query = %params.query` from info_span! call
+
+4. Vector stage
+   ├── Existing: vector_count, result_count
+   └── [NEW] record_stage_scores(span, &chunk_ids_from_vector, &cosine_scores)
+
+5. Fusion stage
+   ├── Existing: candidate_count
+   └── [NEW] record_stage_scores(span, &fused_chunk_ids, &rrf_scores_as_f32)
+
+6. Rerank stage
+   ├── Existing: input_count, output_count
+   └── [NEW] record_stage_scores(span, &rerank_chunk_ids, &rerank_scores)
+
+7. Dedup, min_score, max_tokens truncation — unchanged
+
+8. Build SearchResult
+   └── [CHANGED] include chunk_id in struct literal
+
+9. [NEW] Record result_chunk_ids on root span
+   └── Span::current().record("result_chunk_ids", final_chunk_ids_json.as_str())
+
+10. Quality span — unchanged
+```
+
+### 4.6 Testing
+
+New unit test in `search.rs`:
+
+1. Set up a fixture: tiny in-memory corpus (3 entries, 5 chunks), build redb+tantivy indexes, construct an Embedder against a mock or stubbed backend.
+2. Configure tracing to write to a temp `.jsonl` file via `OtlpFileExporter`.
+3. Issue a `search_with_handles()` call.
+4. Force-flush the exporter; read the trace file.
+5. Assert:
+   - Root span `corvia.search` has `query = "<original>"` and `result_chunk_ids` is a parseable JSON array of strings.
+   - Each sub-span has `chunk_ids` and `scores` as JSON-string attrs, parseable and same length.
+   - `SearchResponse.results[i].chunk_id` is non-empty.
+
+Existing tests (`rrf_fusion_*`, `quality_signal_*`, `compute_quality_signal`) unaffected by this change.
+
+Test harness concern: `search_with_handles` requires a real `Embedder`, which calls fastembed-rs ONNX runtime. The integration test fixture must either:
+- Use a small pre-downloaded model (existing pattern — see any existing search integration tests), or
+- Skip if the model isn't cached (`#[ignore]`-gate for CI).
+
+Investigation item for planning: check existing search integration tests to reuse their fixture approach.
+
+### 4.7 Performance
+
+Per-search added cost:
+- 4 `serde_json::to_string` calls on `Vec<String>` and `Vec<f32>` of size ≤60 — microseconds.
+- 8 `Span::record()` calls — negligible (tracing already sinks to a bounded queue).
+- 1 additional JSON stringify for `result_chunk_ids` (size ≤10).
+
+Total added latency: <1ms per search, well under the <1% p95 threshold in AC #6 (search p95 is tens to hundreds of ms).
+
+### 4.8 Integration with `corvia_traces` MCP tool
+
+Already handled by the existing implementation:
+- `parse_otlp_attribute_value` in `trace.rs:182` returns strings for `stringValue` attrs.
+- `TraceEntry.attributes: HashMap<String, serde_json::Value>` already carries arbitrary attr shapes.
+- Downstream consumers (MCP clients, eval harness) do `json.loads(attrs["chunk_ids"])` to materialize the array.
+
+No change needed to `corvia_traces` or the MCP tool schema. New fields surface automatically.
+
+## 5. Acceptance criteria mapping
+
+| Original AC | Coverage |
+|---|---|
+| 1. `SearchResult` includes chunk ID | §4.1 |
+| 2. `corvia.search` exports raw query (redactable via env flag) | §4.2 — raw query yes; env flag dropped (see §3) |
+| 3. Per-stage scores exported on sub-spans | §4.2, §4.4, §4.5 |
+| 4. `corvia_traces` MCP tool shows new fields | §4.8 — automatic |
+| 5. Unit test: search produces trace with all new fields | §4.6 |
+| 6. No performance regression (<1% p95) | §4.7 |
+
+## 6. Risks
+
+- **Test-fixture complexity.** `search_with_handles` has many moving parts (redb, tantivy, Embedder); building a minimal trace-assert fixture may be the biggest implementation cost. Mitigated by reusing existing integration-test patterns.
+- **JSON-string attr convention.** Introducing "JSON-encoded arrays as string attrs" establishes a pattern other spans may adopt. Alternatively, we could fix the OTLP exporter to serialize arrays natively. This design chooses the local workaround to keep scope contained; a proper exporter fix can come later.
+
+## 7. Open items deferred to implementation plan
+
+- Pick the exact test-fixture approach (in-memory subset of an existing test, or new tempdir-based fixture).
+- Confirm no other `SearchResult {}` construction sites exist beyond `search.rs` + existing test module. If any, update them in the same PR.

--- a/docs/rfcs/2026-04-18-search-telemetry-extension-plan.md
+++ b/docs/rfcs/2026-04-18-search-telemetry-extension-plan.md
@@ -1,0 +1,891 @@
+# Search Telemetry Extension — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add chunk-level identity, raw query, and per-stage scores to `corvia.search` telemetry so downstream eval tickets (#124–#129) can mine traces for recall@k, matched-pair regression, and stage-level diagnostics.
+
+**Architecture:** Additive struct field on `SearchResult` (`chunk_id: String`); one private helper fn `record_stage_scores` on a `Span` that JSON-encodes parallel `chunk_ids` + `scores` arrays; root span records raw `query` + final `result_chunk_ids`. No retrieval-logic changes.
+
+**Tech Stack:** Rust 2024, `tracing` + `tracing-opentelemetry` + `opentelemetry_sdk`, existing `OtlpFileExporter` (in `corvia-core/src/trace.rs`), existing `TestHarness` fixture in `corvia-core/tests/common/mod.rs`.
+
+**Design doc:** `repos/corvia/docs/rfcs/2026-04-18-search-telemetry-extension-design.md`
+
+**Branch:** `feat/123-telemetry-search-span` (already created; design doc committed at `9420b92`).
+
+**Repo root for all commands:** `/workspaces/corvia-workspace/repos/corvia/`
+
+---
+
+## Context the engineer must know
+
+1. **Crate layout**: `corvia-core` holds retrieval logic (search, types, trace exporter). `corvia-cli` holds binary, telemetry init (`init_telemetry`), and the MCP server. The unit-test-side subscriber wiring lives in `corvia-cli`; tests inside `corvia-core` cannot rely on `init_telemetry` and must stand up their own provider.
+
+2. **Telemetry pipeline**: `tracing::info_span!` → `tracing-opentelemetry` bridge → `opentelemetry_sdk::SdkTracerProvider` → `simple_exporter(OtlpFileExporter)` → JSON line in `.corvia/traces.jsonl`. `simple_exporter` flushes synchronously on span close.
+
+3. **Span recording rules**: `Span::current().record("name", value)` only works if the span declared `name = tracing::field::Empty` (or some literal) at creation time. Fields not pre-declared are silently dropped. Every new attr this plan adds MUST be declared in the `info_span!`/`#[tracing::instrument]` macro first.
+
+4. **OTLP array quirk**: The exporter at `crates/corvia-core/src/trace.rs:72` serializes `opentelemetry::Value::Array` via `format!("{:?}", value)` — debug-stringified, not machine-parseable. This is why the design encodes arrays as JSON strings locally via `serde_json::to_string` and records them as `stringValue` attrs. Do NOT pass `&[String]` directly to `.record()`.
+
+5. **Construction sites of `SearchResult`**: Verified grep shows exactly **one** production construction site: `crates/corvia-core/src/search.rs:418`. No Rust test code constructs `SearchResult` as a struct literal — tests read `.id`, `.score`, `.kind`, `.content` via field access. Adding a required `chunk_id` field will therefore only break that one site.
+
+6. **Integration test gate**: Tests that need an `Embedder` are `#[ignore]`-gated throughout this codebase (see `tests/integration.rs:29`, `src/search.rs:604`). Follow that convention — CI doesn't run them; local runs use `cargo test -- --ignored`.
+
+---
+
+## File plan
+
+| File | Change |
+|---|---|
+| `crates/corvia-core/src/types.rs` | Add `pub chunk_id: String` to `SearchResult`. Update serde roundtrip test if needed. |
+| `crates/corvia-core/src/search.rs` | Six targeted changes (see Tasks 2–6). Add one private helper fn `record_stage_scores` + a pure `encode_stage_scores` for testability. |
+| `crates/corvia-core/Cargo.toml` | Add `tracing-opentelemetry` and `tracing-subscriber` to `[dev-dependencies]` (the main `tracing-subscriber` is already a regular dep; confirm). |
+| `crates/corvia-core/tests/integration.rs` | Add one new `#[ignore]` integration test `search_emits_eval_telemetry_attributes`. |
+
+Total: 3 files modified + 1 test added.
+
+---
+
+## Task 1: Add `chunk_id` field to `SearchResult`
+
+**Files:**
+- Modify: `crates/corvia-core/src/types.rs` (struct at line 101)
+- Modify: `crates/corvia-core/src/search.rs:418` (only construction site; will fail to compile until fixed → proves nothing else constructs this struct)
+
+- [ ] **Step 1: Write the failing test**
+
+Append this test at the end of the `tests` module in `crates/corvia-core/src/types.rs` (before the final `}`):
+
+```rust
+    #[test]
+    fn search_result_carries_chunk_id() {
+        let r = SearchResult {
+            id: "entry-1".to_string(),
+            chunk_id: "entry-1:3".to_string(),
+            kind: Kind::Learning,
+            score: 0.5,
+            content: "body".to_string(),
+        };
+        assert_eq!(r.chunk_id, "entry-1:3");
+        assert_eq!(r.id, "entry-1");
+    }
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+Run: `cargo test -p corvia-core --lib types::tests::search_result_carries_chunk_id 2>&1 | tail -30`
+
+Expected: compile error `missing field 'chunk_id' in initializer of 'SearchResult'` OR `struct 'SearchResult' has no field named 'chunk_id'` (depending on which line rustc reaches first — both prove the field isn't there yet).
+
+- [ ] **Step 3: Add the field**
+
+Modify `crates/corvia-core/src/types.rs` — replace the `SearchResult` struct at line 101 with:
+
+```rust
+/// A single search result returned by the retrieval pipeline.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchResult {
+    /// Entry ID (UUIDv7) of the source entry.
+    pub id: String,
+    /// Chunk ID of the specific chunk retrieved from the entry. Format `<entry_id>:<chunk_index>`.
+    pub chunk_id: String,
+    pub kind: Kind,
+    pub score: f32,
+    pub content: String,
+}
+```
+
+- [ ] **Step 4: Update the single production construction site**
+
+Modify `crates/corvia-core/src/search.rs` — replace the block at lines 418-423:
+
+```rust
+        results.push(SearchResult {
+            id: entry_id,
+            chunk_id: chunk_id.clone(),
+            kind,
+            score,
+            content,
+        });
+```
+
+Note: the loop at line 412 destructures `(chunk_id, entry_id, score, content)` — `chunk_id` is already in scope. Clone it because the original binding is consumed by nothing else in this loop iteration but we take ownership of `entry_id`/`content` in the struct literal.
+
+Actually verify: the tuple is destructured with `for (chunk_id, entry_id, score, content) in scored_results`, and the values are moved into the struct. Since `entry_id` and `content` are `String` (moved), and `score` is `f32` (Copy), the `chunk_id: String` is still available to be moved. We can move it in too, no clone needed. Use:
+
+```rust
+        results.push(SearchResult {
+            id: entry_id,
+            chunk_id,
+            kind,
+            score,
+            content,
+        });
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo test -p corvia-core --lib types::tests::search_result_carries_chunk_id`
+
+Expected: `test result: ok. 1 passed; 0 failed`.
+
+- [ ] **Step 6: Verify no other callers broke**
+
+Run: `cargo build --workspace 2>&1 | tail -20`
+
+Expected: clean compile (no errors). If errors appear in `corvia-cli` or elsewhere, investigate — this means a `SearchResult { ... }` construction site exists that the grep missed; fix it by adding `chunk_id:` to the literal.
+
+- [ ] **Step 7: Run full unit test suite**
+
+Run: `cargo test -p corvia-core --lib 2>&1 | tail -10`
+
+Expected: all pre-existing lib tests pass (the `#[ignore]` integration tests remain skipped).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/corvia-core/src/types.rs crates/corvia-core/src/search.rs
+git commit -m "feat: add chunk_id to SearchResult for eval telemetry
+
+Closes AC #1 of #123."
+```
+
+---
+
+## Task 2: Pure JSON-encoding helper + unit tests
+
+**Files:**
+- Modify: `crates/corvia-core/src/search.rs` (add pure fn + unit tests in the existing `#[cfg(test)] mod tests`)
+
+Rationale: the actual `Span::record` call needs a tracing subscriber to observe. Extracting the encoding as a pure fn lets us test the JSON output shape without any subscriber machinery.
+
+- [ ] **Step 1: Write failing tests for the pure encoder**
+
+Append to the `#[cfg(test)] mod tests { ... }` block in `crates/corvia-core/src/search.rs`, just before the closing `}`:
+
+```rust
+    #[test]
+    fn encode_stage_scores_empty() {
+        let (ids, scores) = encode_stage_scores(&[], &[]);
+        assert_eq!(ids, "[]");
+        assert_eq!(scores, "[]");
+    }
+
+    #[test]
+    fn encode_stage_scores_parallel_arrays() {
+        let chunk_ids = vec!["a:0".to_string(), "b:1".to_string(), "c:2".to_string()];
+        let scores = vec![0.9f32, 0.5, 0.1];
+        let (ids_json, scores_json) = encode_stage_scores(&chunk_ids, &scores);
+        assert_eq!(ids_json, r#"["a:0","b:1","c:2"]"#);
+        assert_eq!(scores_json, "[0.9,0.5,0.1]");
+    }
+
+    #[test]
+    fn encode_stage_scores_length_mismatch_still_encodes_both() {
+        // Caller's responsibility to pass parallel arrays; function must not crash.
+        let chunk_ids = vec!["a".to_string()];
+        let scores = vec![0.1f32, 0.2, 0.3];
+        let (ids_json, scores_json) = encode_stage_scores(&chunk_ids, &scores);
+        assert_eq!(ids_json, r#"["a"]"#);
+        assert_eq!(scores_json, "[0.1,0.2,0.3]");
+    }
+```
+
+- [ ] **Step 2: Confirm the test fails to compile**
+
+Run: `cargo test -p corvia-core --lib search::tests::encode_stage_scores_empty 2>&1 | tail -15`
+
+Expected: `error[E0425]: cannot find function 'encode_stage_scores' in this scope`.
+
+- [ ] **Step 3: Add the pure encoder near the top of `search.rs` helpers**
+
+Add after the `FusedCandidate` struct definition (around line 40) in `crates/corvia-core/src/search.rs`:
+
+```rust
+/// Encode parallel `chunk_ids` and `scores` arrays as JSON strings.
+///
+/// The OTLP file exporter serializes `opentelemetry::Value::Array` via debug
+/// formatting (`trace.rs:72`), producing strings that are not machine-parseable.
+/// Encoding as JSON strings and recording them as `stringValue` attrs lets
+/// downstream consumers parse via `json::parse` cleanly.
+///
+/// Returns `("[]", "[]")` on any (impossible-for-these-types) serde error
+/// so that attr presence is preserved even in unreachable edge cases.
+fn encode_stage_scores(chunk_ids: &[String], scores: &[f32]) -> (String, String) {
+    let ids = serde_json::to_string(chunk_ids).unwrap_or_else(|_| "[]".to_string());
+    let sc = serde_json::to_string(scores).unwrap_or_else(|_| "[]".to_string());
+    (ids, sc)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p corvia-core --lib search::tests::encode_stage_scores`
+
+Expected: `test result: ok. 3 passed; 0 failed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/corvia-core/src/search.rs
+git commit -m "feat: add encode_stage_scores pure helper for span attrs
+
+Encodes parallel chunk_ids+scores arrays as JSON strings to work around
+the OTLP file exporter's debug-stringification of Value::Array. Tested
+in isolation; Span::record wiring comes in subsequent tasks."
+```
+
+---
+
+## Task 3: Record raw `query` on the root search span
+
+**Files:**
+- Modify: `crates/corvia-core/src/search.rs` — the `#[tracing::instrument]` attribute at line 177 and the function body.
+
+- [ ] **Step 1: Declare `query` as an Empty field on the root span macro**
+
+In `crates/corvia-core/src/search.rs`, replace the `#[tracing::instrument]` attribute at lines 177-183:
+
+```rust
+#[tracing::instrument(name = "corvia.search", skip(config, base_dir, embedder, params, redb, tantivy), fields(
+    query = tracing::field::Empty,
+    query_len = params.query.len(),
+    limit = params.limit,
+    kind_filter = ?params.kind,
+    result_count = tracing::field::Empty,
+    result_chunk_ids = tracing::field::Empty,
+    confidence = tracing::field::Empty,
+))]
+```
+
+(Adds `query` and `result_chunk_ids` as empty placeholders alongside existing fields. `result_chunk_ids` is filled in Task 5; `query` right now.)
+
+- [ ] **Step 2: Record the raw query at the top of `search_with_handles`**
+
+Insert as the first executable line inside `search_with_handles` (after the opening brace on line 191, before the cold-start check):
+
+```rust
+    // Record raw query for eval mining. Design RFC §4.2: no redaction toggle —
+    // corvia is single-user local; raw query is the eval join key.
+    Span::current().record("query", params.query.as_str());
+```
+
+- [ ] **Step 3: Build & test**
+
+Run: `cargo build -p corvia-core 2>&1 | tail -10`
+
+Expected: clean compile.
+
+Run: `cargo test -p corvia-core --lib 2>&1 | tail -10`
+
+Expected: all non-`#[ignore]` tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/corvia-core/src/search.rs
+git commit -m "feat: record raw query on corvia.search root span
+
+Per RFC §4.2. Raw query is the eval join key for matched-pair
+regression downstream (#125-#129). No redaction toggle — corvia is
+single-user local; threat model doesn't require it.
+
+Partial: AC #2 of #123 (query attr; result_chunk_ids in Task 5)."
+```
+
+---
+
+## Task 4: Wire per-stage score recording in sub-spans
+
+**Files:**
+- Modify: `crates/corvia-core/src/search.rs` — the bm25, vector, fusion, rerank sub-span blocks.
+
+This task touches four stages. Each stage follows an identical pattern:
+1. Declare `chunk_ids = Empty, scores = Empty` on the `info_span!`.
+2. Collect chunk_ids and scores from the stage's output into parallel `Vec`s.
+3. Call `encode_stage_scores` + `Span::current().record(...)` inside the stage block (before the scope closes).
+
+Also: **remove** the redundant `query = %params.query` from the bm25 sub-span (now on parent).
+
+- [ ] **Step 1: Add a private helper that records both attrs on the current span**
+
+Insert right after the `encode_stage_scores` function added in Task 2 (same region of `search.rs`):
+
+```rust
+/// Record `chunk_ids` and `scores` as JSON-string attrs on the given span.
+/// Both fields must have been declared on the `info_span!` with `tracing::field::Empty`.
+fn record_stage_scores(span: &tracing::Span, chunk_ids: &[String], scores: &[f32]) {
+    let (ids_json, scores_json) = encode_stage_scores(chunk_ids, scores);
+    span.record("chunk_ids", ids_json.as_str());
+    span.record("scores", scores_json.as_str());
+}
+```
+
+- [ ] **Step 2: Wire BM25 stage**
+
+Find lines 237-245 in `search.rs`. Replace the entire BM25 block with:
+
+```rust
+    // Step 5: BM25 search.
+    let bm25_results = {
+        let _span = info_span!(
+            "corvia.search.bm25",
+            result_count = tracing::field::Empty,
+            chunk_ids = tracing::field::Empty,
+            scores = tracing::field::Empty,
+        )
+        .entered();
+        let results = tantivy
+            .search(&params.query, params.kind, retrieval_limit)
+            .context("BM25 search")?;
+        Span::current().record("result_count", results.len());
+
+        // Record chunk_ids + BM25 raw scores for eval mining.
+        let ids: Vec<String> = results.iter().map(|(cid, _, _)| cid.clone()).collect();
+        let scores: Vec<f32> = results.iter().map(|(_, _, s)| *s).collect();
+        record_stage_scores(&Span::current(), &ids, &scores);
+
+        debug!(count = results.len(), "BM25 results");
+        results
+    };
+```
+
+Changes vs. original (lines 237-245):
+- Removed `query = %params.query` from the span macro (redundant with root).
+- Added `chunk_ids = Empty, scores = Empty` declarations.
+- Added the `ids`/`scores` collection + `record_stage_scores` call.
+
+- [ ] **Step 3: Wire vector stage**
+
+Find the vector block starting at line 248. Replace the `info_span!` macro call and add the score-recording block. The replacement block:
+
+```rust
+    // Step 6: Vector search.
+    let vector_scored = {
+        let _span = info_span!(
+            "corvia.search.vector",
+            vector_count = tracing::field::Empty,
+            result_count = tracing::field::Empty,
+            chunk_ids = tracing::field::Empty,
+            scores = tracing::field::Empty,
+        )
+        .entered();
+        let query_vector = embedder
+            .embed(&params.query)
+            .context("embedding search query")?;
+
+        let all_vectors = redb.all_vectors().context("loading all vectors from redb")?;
+        let superseded_ids = redb.superseded_ids().context("loading superseded IDs")?;
+        Span::current().record("vector_count", all_vectors.len());
+
+        let mut scored: Vec<(String, String, f32)> = Vec::new();
+        for (chunk_id, vector) in &all_vectors {
+            let entry_id = match redb.chunk_entry_id(chunk_id)? {
+                Some(eid) => eid,
+                None => continue,
+            };
+            if superseded_ids.contains(&entry_id) {
+                continue;
+            }
+            if let Some(ref kind_filter) = params.kind {
+                if let Ok(Some(chunk_kind_str)) = redb.get_chunk_kind(chunk_id) {
+                    if let Ok(chunk_kind) = chunk_kind_str.parse::<Kind>() {
+                        if chunk_kind != *kind_filter {
+                            continue;
+                        }
+                    }
+                }
+            }
+            let similarity = Embedder::cosine_similarity(&query_vector, vector);
+            scored.push((chunk_id.clone(), entry_id, similarity));
+        }
+        scored.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
+        scored.truncate(retrieval_limit);
+        Span::current().record("result_count", scored.len());
+
+        // Record chunk_ids + cosine scores for eval mining.
+        let ids: Vec<String> = scored.iter().map(|(cid, _, _)| cid.clone()).collect();
+        let scores_vec: Vec<f32> = scored.iter().map(|(_, _, s)| *s).collect();
+        record_stage_scores(&Span::current(), &ids, &scores_vec);
+
+        debug!(count = scored.len(), "vector results");
+        scored
+    };
+```
+
+- [ ] **Step 4: Wire fusion stage**
+
+Find the fusion block at line 287. Replace with:
+
+```rust
+    // Step 7: RRF fusion.
+    let fused = {
+        let _span = info_span!(
+            "corvia.search.fusion",
+            candidate_count = tracing::field::Empty,
+            chunk_ids = tracing::field::Empty,
+            scores = tracing::field::Empty,
+        )
+        .entered();
+        let result = rrf_fusion(&bm25_results, &vector_scored, config.search.rrf_k);
+        Span::current().record("candidate_count", result.len());
+
+        // Record chunk_ids + RRF scores (f64 → f32) for eval mining.
+        let ids: Vec<String> = result.iter().map(|c| c.chunk_id.clone()).collect();
+        let scores_vec: Vec<f32> = result.iter().map(|c| c.rrf_score as f32).collect();
+        record_stage_scores(&Span::current(), &ids, &scores_vec);
+
+        debug!(count = result.len(), "fused candidates");
+        result
+    };
+```
+
+Note: RRF scores are `f64` internally (for rank sum precision); the cast to `f32` is a documented precision loss for telemetry only — retrieval ranking uses `f64` throughout.
+
+- [ ] **Step 5: Wire rerank stage**
+
+The rerank block starts at line 300 with `info_span!("corvia.search.rerank", input_count = ..., output_count = Empty)`. The pattern is the same but the bound variable is `results` (a `Vec<(String, String, f32, String)>` where `.0` is chunk_id, `.2` is score).
+
+Replace the `info_span!` macro call and add score recording right before `Span::current().record("output_count", ...)`. The final span header:
+
+```rust
+        let _span = info_span!(
+            "corvia.search.rerank",
+            input_count = top_candidates.len(),
+            output_count = tracing::field::Empty,
+            chunk_ids = tracing::field::Empty,
+            scores = tracing::field::Empty,
+        )
+        .entered();
+```
+
+At the END of the rerank block, just before `Span::current().record("output_count", results.len()); results`, insert:
+
+```rust
+        // Record chunk_ids + reranker (or RRF-fallback) scores for eval mining.
+        let ids: Vec<String> = results.iter().map(|(cid, _, _, _)| cid.clone()).collect();
+        let rerank_scores: Vec<f32> = results.iter().map(|(_, _, s, _)| *s).collect();
+        record_stage_scores(&Span::current(), &ids, &rerank_scores);
+```
+
+So the tail of the rerank block becomes:
+
+```rust
+        // Record chunk_ids + reranker (or RRF-fallback) scores for eval mining.
+        let ids: Vec<String> = results.iter().map(|(cid, _, _, _)| cid.clone()).collect();
+        let rerank_scores: Vec<f32> = results.iter().map(|(_, _, s, _)| *s).collect();
+        record_stage_scores(&Span::current(), &ids, &rerank_scores);
+
+        Span::current().record("output_count", results.len());
+        results
+    };
+```
+
+- [ ] **Step 6: Build & test**
+
+Run: `cargo build -p corvia-core 2>&1 | tail -10`
+
+Expected: clean compile.
+
+Run: `cargo test -p corvia-core --lib 2>&1 | tail -15`
+
+Expected: all non-ignored tests pass; RRF/quality/encode tests still pass.
+
+Run: `cargo clippy -p corvia-core --all-targets 2>&1 | tail -20`
+
+Expected: no new warnings. Pay attention to any `unused_variables` — the `ids` and `scores_vec` shadowing across stage blocks should be fine since they're scope-local to each `let { ... }` block.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/corvia-core/src/search.rs
+git commit -m "feat: record per-stage chunk_ids and scores on search sub-spans
+
+Each of corvia.search.{bm25,vector,fusion,rerank} now carries
+chunk_ids + scores as JSON-string attrs parallel to the stage's
+output. Also drops the redundant query attr from bm25 (now on parent).
+
+Closes AC #3 of #123."
+```
+
+---
+
+## Task 5: Record `result_chunk_ids` on the root span
+
+**Files:**
+- Modify: `crates/corvia-core/src/search.rs` — around line 409 (after `final_scores` is collected, before/after `SearchResult` construction).
+
+The instrument macro was already updated in Task 3 to declare `result_chunk_ids = Empty`.
+
+- [ ] **Step 1: Collect final chunk_ids alongside `final_scores`**
+
+Find line 409 in `search.rs`:
+
+```rust
+    // Step 12: Build SearchResult for each.
+    let final_scores: Vec<f32> = scored_results.iter().map(|(_, _, s, _)| *s).collect();
+```
+
+Replace with:
+
+```rust
+    // Step 12: Build SearchResult for each.
+    let final_scores: Vec<f32> = scored_results.iter().map(|(_, _, s, _)| *s).collect();
+    let final_chunk_ids: Vec<String> =
+        scored_results.iter().map(|(cid, _, _, _)| cid.clone()).collect();
+```
+
+- [ ] **Step 2: Record the JSON-encoded chunk_ids on the root span**
+
+Find the line around 439-440:
+
+```rust
+    Span::current().record("result_count", results.len());
+    Span::current().record("confidence", tracing::field::debug(quality.confidence));
+```
+
+Insert directly above these (after the quality block closes):
+
+```rust
+    // Record final (post-truncation) chunk_ids for downstream eval join.
+    let result_chunk_ids_json =
+        serde_json::to_string(&final_chunk_ids).unwrap_or_else(|_| "[]".to_string());
+    Span::current().record("result_chunk_ids", result_chunk_ids_json.as_str());
+```
+
+Final section becomes:
+
+```rust
+    // Record final (post-truncation) chunk_ids for downstream eval join.
+    let result_chunk_ids_json =
+        serde_json::to_string(&final_chunk_ids).unwrap_or_else(|_| "[]".to_string());
+    Span::current().record("result_chunk_ids", result_chunk_ids_json.as_str());
+
+    Span::current().record("result_count", results.len());
+    Span::current().record("confidence", tracing::field::debug(quality.confidence));
+
+    info!(
+        results = results.len(),
+        confidence = ?quality.confidence,
+        "search complete"
+    );
+
+    Ok(SearchResponse { results, quality })
+```
+
+- [ ] **Step 3: Build & test**
+
+Run: `cargo build -p corvia-core 2>&1 | tail -10`
+
+Expected: clean compile.
+
+Run: `cargo test -p corvia-core --lib 2>&1 | tail -10`
+
+Expected: all existing tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/corvia-core/src/search.rs
+git commit -m "feat: record result_chunk_ids on corvia.search root span
+
+Final (post-truncation) top-K chunk_ids encoded as JSON-string attr
+for eval-harness join with an external golden set. Per RFC §4.2.
+
+Completes AC #2 of #123 (with Task 3's query attr)."
+```
+
+---
+
+## Task 6 [POC]: End-to-end trace-capture integration test
+
+**[POC] justification:** This test exercises the full tracing stack (tracing + tracing-opentelemetry + SdkTracerProvider + OtlpFileExporter + tempfile I/O + tokio). Two assumptions the POC validates:
+
+1. **`tracing::subscriber::with_default(subscriber, || { ... })` properly scopes OTel span emission to the closure.** In particular, that spans emitted from inside the closure are routed to the local subscriber's `OpenTelemetryLayer`, and that the closure's thread-local dispatch dance doesn't drop spans.
+2. **A locally-constructed `SdkTracerProvider` with `with_simple_exporter(OtlpFileExporter)` flushes synchronously on span close, so that reading the tempfile immediately after the search call returns complete data.**
+
+Both are likely true based on how the binary's `init_telemetry` is structured, but neither has been exercised from a pure unit-test context. If either fails, fall back to: mark the test `#[ignore]`, delete the file-readback, and cover the new attrs via a separate test that uses a custom `SpanExporter` mock storing spans in a `Mutex<Vec<SpanData>>`. That fallback is documented inline.
+
+**Files:**
+- Modify: `crates/corvia-core/Cargo.toml` — add `tracing-opentelemetry` dev-dep.
+- Modify: `crates/corvia-core/tests/integration.rs` — add new test.
+
+- [ ] **Step 1: Add `tracing-opentelemetry` as a dev-dep**
+
+Modify `crates/corvia-core/Cargo.toml`. The existing `[dev-dependencies]` section has one line (`tempfile = "3"`). Replace it with:
+
+```toml
+[dev-dependencies]
+tempfile = "3"
+tracing-opentelemetry = { workspace = true }
+```
+
+(`workspace = true` uses the version pinned in the root `Cargo.toml` workspace deps table — already `"0.29"`.)
+
+- [ ] **Step 2: Write the failing integration test**
+
+Add to `crates/corvia-core/tests/integration.rs`, appending after the last test (the file is ~900 lines; add at the bottom, before the final `}` of any module if present, or at the top-level if tests are flat):
+
+```rust
+// ---------------------------------------------------------------------------
+// Telemetry: #123 [eval 1/7]
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore] // requires embedding model + writes a tempfile
+fn search_emits_eval_telemetry_attributes() {
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_sdk::trace::SdkTracerProvider;
+    use tracing_subscriber::layer::SubscriberExt;
+    use corvia_core::trace::{read_recent_traces, OtlpFileExporter};
+
+    let h = common::TestHarness::new();
+    let config = &h.config;
+    let base = h.base_dir();
+    h.copy_fixtures();
+
+    // Ingest fixtures so the search has something to retrieve.
+    let _ingest = corvia_core::ingest::ingest(config, base, false)
+        .expect("ingest failed");
+
+    // Set up a local tracer provider pointing at a tempfile.
+    let trace_dir = tempfile::tempdir().unwrap();
+    let trace_path = trace_dir.path().join("traces.jsonl");
+    let file_exporter = OtlpFileExporter::new(trace_path.clone())
+        .expect("failed to create file exporter");
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(file_exporter)
+        .build();
+    let tracer = provider.tracer("corvia-test");
+
+    // Compose: subscriber with the otel layer so tracing spans reach the provider.
+    let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+    let subscriber = tracing_subscriber::registry().with(otel_layer);
+
+    let embedder = make_embedder(config);
+
+    // Run search inside the subscriber scope.
+    tracing::subscriber::with_default(subscriber, || {
+        let params = SearchParams {
+            query: "why did we choose Redb".to_string(),
+            limit: 5,
+            max_tokens: None,
+            min_score: None,
+            kind: None,
+        };
+        let response = search(config, base, &embedder, &params).unwrap();
+        assert!(
+            !response.results.is_empty(),
+            "search should return results from fixtures"
+        );
+        assert!(
+            response.results.iter().all(|r| !r.chunk_id.is_empty()),
+            "every SearchResult must carry a non-empty chunk_id"
+        );
+    });
+
+    // Flush: drop the provider to shut down and flush buffered spans.
+    drop(provider);
+
+    // Read back the trace file and locate the corvia.search root span.
+    let traces = read_recent_traces(&trace_path, 200);
+    assert!(
+        !traces.is_empty(),
+        "trace file should contain at least one span; path: {}",
+        trace_path.display()
+    );
+
+    let root = traces
+        .iter()
+        .find(|t| t.name == "corvia.search")
+        .expect("corvia.search root span not found in trace file");
+
+    // Root span: raw query present
+    let query_attr = root
+        .attributes
+        .get("query")
+        .and_then(|v| v.as_str())
+        .expect("corvia.search.query attr missing or wrong type");
+    assert_eq!(query_attr, "why did we choose Redb");
+
+    // Root span: result_chunk_ids is a JSON-array string
+    let ids_attr = root
+        .attributes
+        .get("result_chunk_ids")
+        .and_then(|v| v.as_str())
+        .expect("corvia.search.result_chunk_ids attr missing");
+    let ids: Vec<String> = serde_json::from_str(ids_attr)
+        .expect("result_chunk_ids must parse as JSON string array");
+    assert!(
+        !ids.is_empty(),
+        "result_chunk_ids should be non-empty for a successful search"
+    );
+    assert!(
+        ids.iter().all(|c| c.contains(':')),
+        "chunk_ids should look like '<entry>:<idx>': {ids:?}"
+    );
+
+    // Each sub-span: chunk_ids + scores present as JSON-string arrays of equal length
+    for stage in ["corvia.search.bm25", "corvia.search.vector", "corvia.search.fusion", "corvia.search.rerank"] {
+        let sub = traces
+            .iter()
+            .find(|t| t.name == stage)
+            .unwrap_or_else(|| panic!("sub-span {stage} not found"));
+        let cids_raw = sub
+            .attributes
+            .get("chunk_ids")
+            .and_then(|v| v.as_str())
+            .unwrap_or_else(|| panic!("{stage}.chunk_ids missing"));
+        let scores_raw = sub
+            .attributes
+            .get("scores")
+            .and_then(|v| v.as_str())
+            .unwrap_or_else(|| panic!("{stage}.scores missing"));
+        let cids: Vec<String> = serde_json::from_str(cids_raw)
+            .unwrap_or_else(|e| panic!("{stage}.chunk_ids bad JSON: {e}"));
+        let scores: Vec<f32> = serde_json::from_str(scores_raw)
+            .unwrap_or_else(|e| panic!("{stage}.scores bad JSON: {e}"));
+        assert_eq!(
+            cids.len(),
+            scores.len(),
+            "{stage}: chunk_ids and scores must be parallel (same length)"
+        );
+    }
+}
+```
+
+- [ ] **Step 3: Verify the test fails on a clean build (if run)**
+
+Run: `cargo test -p corvia-core --test integration search_emits_eval_telemetry_attributes -- --ignored 2>&1 | tail -25`
+
+Expected: either:
+- **PASS**: POC validated — wiring works. Proceed.
+- **FAIL**: inspect the error. If the failure is "trace file is empty" → the scoped subscriber isn't routing to our provider. Fix: replace `with_default` with `global_default` and accept that this test cannot be run in parallel with other tracing tests (cargo runs `#[ignore]` tests serially when invoked with `-- --ignored --test-threads=1`). If the failure is "attr missing" in a particular stage → that stage's wiring is wrong, jump back to Task 4 for that stage and fix.
+
+Document the outcome in the commit message (below).
+
+- [ ] **Step 4: If POC needed adjustment, iterate**
+
+If `with_default` didn't work, switch to this top-of-test pattern:
+
+```rust
+let _dispatch = tracing::dispatcher::set_default(&tracing::Dispatch::new(subscriber));
+// ... run search ...
+```
+
+Or set globally (serial tests only):
+
+```rust
+tracing::subscriber::set_global_default(subscriber)
+    .expect("only one test may set the global subscriber");
+```
+
+Pick whichever the error output suggests. Document the choice in a comment at the test head.
+
+- [ ] **Step 5: Verify the test passes**
+
+Run: `cargo test -p corvia-core --test integration search_emits_eval_telemetry_attributes -- --ignored --nocapture 2>&1 | tail -30`
+
+Expected: `test result: ok. 1 passed; 0 failed`.
+
+- [ ] **Step 6: Verify no other tests regressed**
+
+Run: `cargo test -p corvia-core -- --ignored --test-threads=1 2>&1 | tail -30`
+
+Expected: all pre-existing ignored integration tests continue to pass (they don't use the new attrs but they exercise the same search path).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/corvia-core/Cargo.toml crates/corvia-core/tests/integration.rs
+git commit -m "test: add E2E trace-capture test for eval telemetry
+
+Adds tracing-opentelemetry dev-dep and an ignored integration test
+that asserts the new search telemetry attrs (query, result_chunk_ids,
+per-stage chunk_ids/scores) appear in the OTLP file exporter output.
+
+Closes AC #5 of #123."
+```
+
+---
+
+## Task 7: Final verification & cleanup
+
+- [ ] **Step 1: Full build**
+
+Run: `cargo build --workspace 2>&1 | tail -10`
+
+Expected: clean compile across `corvia-core` and `corvia-cli`.
+
+- [ ] **Step 2: All lib + unit tests**
+
+Run: `cargo test --workspace --lib 2>&1 | tail -10`
+
+Expected: all pass, zero failures.
+
+- [ ] **Step 3: Ignored integration tests**
+
+Run: `cargo test --workspace -- --ignored --test-threads=1 2>&1 | tail -30`
+
+Expected: all pass. If the pre-existing ingest/search tests fail unexpectedly, investigate — the changes should not affect retrieval behavior.
+
+- [ ] **Step 4: Clippy**
+
+Run: `cargo clippy --workspace --all-targets -- -D warnings 2>&1 | tail -30`
+
+Expected: no warnings. If warnings appear, fix them before concluding. Most likely: `unused_variables` on helper-introduced bindings — add `_` prefix or the `#[allow(unused)]` attribute only if the binding is genuinely unused.
+
+- [ ] **Step 5: Manual smoke (optional but recommended)**
+
+Run one ingest + search against a live corpus to visually inspect the new trace file:
+
+```bash
+cd /workspaces/corvia-workspace/repos/corvia
+rm -rf /tmp/corvia-smoke && mkdir -p /tmp/corvia-smoke/.corvia/entries
+cp crates/corvia-core/tests/fixtures/*.md /tmp/corvia-smoke/.corvia/entries/
+cargo run --release -- --trace-file /tmp/corvia-smoke/traces.jsonl ingest /tmp/corvia-smoke
+cargo run --release -- --trace-file /tmp/corvia-smoke/traces.jsonl search "redb" --base-dir /tmp/corvia-smoke
+# Inspect:
+tail -n 20 /tmp/corvia-smoke/traces.jsonl | jq '.name, .attributes[] | select(.key=="query" or .key=="result_chunk_ids" or .key=="chunk_ids" or .key=="scores")'
+```
+
+Expected to see: `query` as a string, `result_chunk_ids` as a JSON-array-string, per-stage `chunk_ids`+`scores` on each sub-span.
+
+(Verify the CLI actually takes `--trace-file` and `--base-dir` flags — if not, drop this step or adapt.)
+
+- [ ] **Step 6: Confirm no commit was missed**
+
+Run: `git status && git log --oneline origin/master..HEAD`
+
+Expected: clean working tree; commits visible since branch-off.
+
+- [ ] **Step 7: Summary commit (only if cleanup was needed)**
+
+If any clippy fixes or smoke-test-driven adjustments were made, commit them:
+
+```bash
+git add -A
+git commit -m "chore: polish per verification pass
+
+<short description of what was fixed>"
+```
+
+If nothing was needed, skip this step.
+
+---
+
+## Self-review checklist (engineer to run before declaring plan complete)
+
+- [ ] Every AC in the design doc (§5) maps to a task. AC #1 → Task 1; AC #2 → Task 5; AC #3 → Task 4; AC #4 → automatic via existing `corvia_traces` MCP tool (verify in Task 6 via smoke); AC #5 → Task 6; AC #6 → not explicitly benchmarked; the added code is a handful of JSON encodings per search (see RFC §4.7) — if perf is critical, add a `cargo bench` pass.
+- [ ] No tasks depend on fields or functions defined in later tasks (dependency order: 1 → 2 → 3 → 4 → 5 → 6 → 7 is strictly forward).
+- [ ] `encode_stage_scores` signature is consistent: `(&[String], &[f32]) -> (String, String)` everywhere used.
+- [ ] `record_stage_scores` takes `&tracing::Span` (not `Span`) — verify in Task 4 Step 1.
+- [ ] All new span fields (`query`, `result_chunk_ids`, `chunk_ids`, `scores`) are declared as `tracing::field::Empty` on their parent macro before any `.record()` call.
+
+---
+
+## Out-of-scope (deferred)
+
+- Fixing `OtlpFileExporter` to handle `Value::Array` natively (RFC §6.2 risk). Tracked separately if adopted.
+- AC #6 performance benchmark (<1% p95 delta). Added code cost is negligible by inspection; a formal bench lives in the broader #122 eval series (#128 `corvia bench` CLI).
+- Adding redaction / env flag for raw query (deliberate YAGNI, RFC §3).
+- Explicit `duration_ms` sub-span attrs (deliberate YAGNI, RFC §3).


### PR DESCRIPTION
## Summary

Closes #123. Extends the `corvia.search` span with the fields eval mining + stage-level regression diagnosis need: raw query on the root, `result_chunk_ids` on the root, `chunk_ids` + `scores` on each retrieval sub-span (bm25 / vector / fusion / rerank). Also surfaces the chunk ID on every `SearchResult` (field + CLI output).

- 14 commits, 6 feat + 4 fix/refactor + 2 test + 2 docs.
- Design: `docs/rfcs/2026-04-18-search-telemetry-extension-design.md`
- Plan: `docs/rfcs/2026-04-18-search-telemetry-extension-plan.md`
- Post-review fixes: 13 addressed across 5 commits (ef47c6e, 252ba40, c785bfb, 393d0a2, ac8b6e3).

### Intentional design deviation
Issue acceptance criterion #2 says "redactable via env flag". The RFC (§3 + §4.2) drops the env flag because corvia is single-user / local / non-hosted and the corpus is known-safe — raw queries are recorded unconditionally, truncated at 4096 UTF-8 chars. Adding a toggle later is a ~10-line PR if a hosted deployment ever materialises. Calling this out explicitly so it's accepted/rejected consciously.

## Acceptance criteria (observed from Phase 8 live E2E, not inferred from code)

- [x] **`SearchResult` includes chunk ID.** MCP `corvia_search` response carries `"chunk_id": "<entry_id>:<chunk_idx>"` per result; CLI prints `[-0.013] (learning) <id> (chunk: <id>:0)` for `corvia search "entries schema migration" --limit 3`.
- [x] **`corvia.search` exports raw query (redactable via env flag).** Root span attributes `query` + `result_chunk_ids` observed live in serve.log and in the OTLP JSON at `.corvia/traces.jsonl`. Query truncated at 4096 chars via `truncate_query` (unit test `records_query_truncates_large_input` passes). Env-flag redaction dropped per RFC §3 (see "Intentional design deviation").
- [x] **Per-stage scores exported on sub-spans.** Live DEBUG logs for a single search show:
  - `corvia.search.bm25`: `result_count=15`, `chunk_ids=[15 ids]`, `scores=[9.559602, 5.182953, …]` — matching lengths.
  - `corvia.search.vector`: `result_count=48`, `chunk_ids=[48 ids]`, `scores=[0.5333267, 0.5245179, …]`.
  - `corvia.search.fusion`: `candidate_count=48`, `chunk_ids=[48 ids]`, `scores=[0.0616, 0.0590, …]` (RRF).
  - `corvia.search.rerank`: records `chunk_ids` + `scores` via `record_stage_scores` at `search.rs:465`; verified by integration test below (no explicit log event, attributes live on the span).
- [x] **`corvia_traces` MCP tool shows the new fields.** `read_recent_traces` at `crates/corvia-core/src/trace.rs:210` parses the OTLP JSON the file exporter writes. New keys (`query`, `result_chunk_ids`, `chunk_ids`, `scores`) appear verbatim in `.corvia/traces.jsonl` as `stringValue` attributes.
- [x] **Unit test populates all new fields on trace.** `search_emits_eval_telemetry_attributes` (integration) asserts root + sub-span attributes end-to-end via the OTLP file exporter. `search_with_impossible_min_score_records_empty_result_chunk_ids` covers the empty-result edge case. Both pass.
- [ ] **No performance regression on search latency (< 1% p95 delta).** Not measured against a baseline — soft verification. Additions are O(N) string clones + one `serde_json::to_string` per span on already-allocated result vectors (sub-ms constant per stage). Flagging in case a reviewer wants a bench before merge.

## Regression

- `cargo build --workspace` — clean.
- `cargo test --workspace --lib` — **102 passed**, 0 failed, 7 ignored.
- `cargo test -p corvia-core --test integration -- --ignored --test-threads=1` — **17 passed**, 0 failed.

## Test plan

- [x] Rebuilt `target/debug/corvia` on the branch, installed to `/usr/local/bin/corvia`, restarted `corvia serve --port 8020`, `/healthz` green.
- [x] Ran live MCP searches against 127.0.0.1:8020 and inspected response payload for `chunk_id`.
- [x] Ran `corvia search` CLI and observed `(chunk: <id>:<idx>)` suffix.
- [x] Enabled `RUST_LOG=info,corvia_core::search=trace,corvia_core=debug` and captured bm25 / vector / fusion sub-span attributes in serve.log.
- [x] Parsed `.corvia/traces.jsonl` OTLP JSON to confirm `query` + `result_chunk_ids` attributes are persisted as `stringValue`.
- [x] Re-ran full lib + integration test suites (including Phase 7 assertions tightened in commit ac8b6e3).
- [ ] Optional: benchmark p95 search latency before/after to close criterion #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)