### PR TITLE
fix(cli): resolve trace file path to workspace root, warn on shadowed .corvia

### DIFF
--- a/crates/corvia-cli/src/main.rs
+++ b/crates/corvia-cli/src/main.rs
@@ -123,15 +123,31 @@ fn load_config(base_dir_arg: Option<&Path>) -> anyhow::Result<(PathBuf, Config)>
     Ok((base_dir, config))
 }
 
+/// Compute the absolute traces.jsonl path for the current invocation, or `None`
+/// if telemetry file output should be skipped.
+///
+/// Returns `None` for `Init` (no `.corvia/` exists yet) and when `.corvia/` cannot
+/// be discovered. Never returns a cwd-relative path — this is what used to cause
+/// stray `.corvia/` directories to appear wherever the binary was launched from.
+fn resolve_trace_path(cli: &Cli) -> Option<PathBuf> {
+    if matches!(cli.command, Command::Init { .. }) {
+        return None;
+    }
+    let base_dir = corvia_core::discover::resolve_base_dir(cli.base_dir.as_deref()).ok()?;
+    let config = Config::load_discovered(&base_dir).ok()?;
+    Some(base_dir.join(&config.data_dir).join("traces.jsonl"))
+}
+
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
 
-    // Initialize telemetry (trace file + OTLP if endpoint provided).
-    let trace_file = Path::new(".corvia/traces.jsonl");
+    // Initialize telemetry (file exporter at the absolute path of the discovered
+    // project's .corvia/traces.jsonl, plus OTLP gRPC if endpoint provided).
+    let trace_path = resolve_trace_path(&cli);
     let _telemetry_guard = telemetry::init_telemetry(
         cli.otlp_endpoint.as_deref(),
-        Some(trace_file),
+        trace_path.as_deref(),
     )
     .expect("failed to initialize telemetry");
 

--- a/crates/corvia-cli/src/telemetry.rs
+++ b/crates/corvia-cli/src/telemetry.rs
@@ -1,9 +1,13 @@
-//! Telemetry initialization: always-on OpenTelemetry + OTLP file exporter + optional gRPC export.
+//! Telemetry initialization: always-on OpenTelemetry + optional OTLP file exporter + optional gRPC export.
 //!
 //! OpenTelemetry instrumentation is always active. A TracerProvider is created
-//! unconditionally so spans always have trace_id and span_id. The OTLP file
-//! exporter writes spans as OTLP JSON lines to `.corvia/traces.jsonl` for local
-//! observability without an external collector.
+//! unconditionally so spans always have trace_id and span_id.
+//!
+//! When a `trace_file` path is supplied, the OTLP file exporter writes spans
+//! as OTLP JSON lines to that absolute path. When `None`, the file exporter
+//! is disabled — callers are expected to resolve the project root and pass an
+//! absolute path, rather than let the exporter fall back to a cwd-relative
+//! `.corvia/traces.jsonl` (which historically created stray `.corvia/` dirs).
 //!
 //! When `--otlp-endpoint` is provided or `OTEL_EXPORTER_OTLP_ENDPOINT` is set,
 //! spans are additionally exported via gRPC to the given collector.
@@ -68,12 +72,13 @@ pub fn init_telemetry(
             .build(),
     );
 
-    // Always: file exporter (OTLP JSON to .corvia/traces.jsonl).
+    // Optional: file exporter (OTLP JSON). No cwd-relative default — if the
+    // caller doesn't supply a path, the file exporter is simply not attached.
     // Uses simple_exporter (sync) so traces flush immediately on span close.
-    let default_path = Path::new(".corvia/traces.jsonl").to_path_buf();
-    let trace_path = trace_file.unwrap_or(&default_path);
-    if let Ok(file_exporter) = OtlpFileExporter::new(trace_path.to_path_buf()) {
-        provider_builder = provider_builder.with_simple_exporter(file_exporter);
+    if let Some(path) = trace_file {
+        if let Ok(file_exporter) = OtlpFileExporter::new(path.to_path_buf()) {
+            provider_builder = provider_builder.with_simple_exporter(file_exporter);
+        }
     }
 
     // Optional: gRPC exporter for external collectors.

--- a/crates/corvia-core/src/discover.rs
+++ b/crates/corvia-core/src/discover.rs
@@ -6,22 +6,66 @@ use anyhow::{bail, Result};
 
 /// Walk up from `start` to find a directory containing `.corvia/corvia.toml`.
 /// Returns the project root (parent of `.corvia/`).
+///
+/// If additional `.corvia/corvia.toml` files exist further up the directory
+/// tree (the closer one shadowing one or more enclosing stores), emits a
+/// `tracing::warn!` so the operator notices the misconfiguration. The closest
+/// root is still returned so behavior is unchanged — only visibility improves.
 pub fn find_project_root(start: &Path) -> Result<PathBuf> {
+    let (root, shadowed) = find_project_root_with_ancestors(start)?;
+    if !shadowed.is_empty() {
+        let ancestors = shadowed
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        tracing::warn!(
+            target: "corvia.discover",
+            active_root = %root.display(),
+            shadowed_ancestors = %ancestors,
+            "Multiple .corvia/ roots found on walk-up path. Using the closest one ({}); \
+             the following enclosing .corvia/ are being shadowed: {}. \
+             This usually means `corvia init` ran in a subdirectory by mistake. \
+             Consider removing the inner store to consolidate state.",
+            root.display(),
+            ancestors
+        );
+    }
+    Ok(root)
+}
+
+/// Internal variant of [`find_project_root`] that surfaces shadowed ancestor
+/// roots instead of warning about them. The first element of the returned tuple
+/// is the closest root; the second is every enclosing root that would be
+/// shadowed by it, in walk-up order.
+fn find_project_root_with_ancestors(start: &Path) -> Result<(PathBuf, Vec<PathBuf>)> {
     let mut current = start
         .canonicalize()
         .unwrap_or_else(|_| start.to_path_buf());
 
+    let mut primary: Option<PathBuf> = None;
+    let mut shadowed: Vec<PathBuf> = Vec::new();
+
     loop {
         let candidate = current.join(".corvia").join("corvia.toml");
         if candidate.is_file() {
-            return Ok(current);
+            if primary.is_none() {
+                primary = Some(current.clone());
+            } else {
+                shadowed.push(current.clone());
+            }
         }
         if !current.pop() {
-            bail!(
-                "No .corvia/ found (searched from {}). Run 'corvia init' to set up.",
-                start.display()
-            );
+            break;
         }
+    }
+
+    match primary {
+        Some(root) => Ok((root, shadowed)),
+        None => bail!(
+            "No .corvia/ found (searched from {}). Run 'corvia init' to set up.",
+            start.display()
+        ),
     }
 }
 
@@ -97,5 +141,47 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let result = resolve_base_dir(Some(dir.path()));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn shadowed_enclosing_root_is_detected() {
+        // Outer .corvia/ at dir/, inner .corvia/ at dir/subdir/.
+        let dir = TempDir::new().unwrap();
+        let outer = dir.path().join(".corvia");
+        std::fs::create_dir_all(&outer).unwrap();
+        std::fs::write(outer.join("corvia.toml"), "").unwrap();
+
+        let inner_root = dir.path().join("subdir");
+        let inner = inner_root.join(".corvia");
+        std::fs::create_dir_all(&inner).unwrap();
+        std::fs::write(inner.join("corvia.toml"), "").unwrap();
+
+        let (primary, shadowed) = find_project_root_with_ancestors(&inner_root).unwrap();
+        let canonical_outer = dir.path().canonicalize().unwrap();
+        let canonical_inner = inner_root.canonicalize().unwrap();
+
+        assert_eq!(primary, canonical_inner, "closest root wins");
+        assert_eq!(
+            shadowed,
+            vec![canonical_outer],
+            "enclosing root is reported as shadowed"
+        );
+
+        // Public API returns the same primary and doesn't error.
+        assert_eq!(find_project_root(&inner_root).unwrap(), canonical_inner);
+    }
+
+    #[test]
+    fn no_shadowed_ancestors_when_only_one_root() {
+        let dir = TempDir::new().unwrap();
+        let corvia = dir.path().join(".corvia");
+        std::fs::create_dir_all(&corvia).unwrap();
+        std::fs::write(corvia.join("corvia.toml"), "").unwrap();
+
+        let sub = dir.path().join("src").join("deep");
+        std::fs::create_dir_all(&sub).unwrap();
+
+        let (_, shadowed) = find_project_root_with_ancestors(&sub).unwrap();
+        assert!(shadowed.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Two related fixes for the root cause of stray `.corvia/` directories appearing in sub-directories of the workspace (`repos/corvia/.corvia/`, `.devcontainer/.corvia/`, `tools/*/​.corvia/`).

- **Trace file path**: `corvia-cli/src/main.rs` used to hardcode a cwd-relative `Path::new(\".corvia/traces.jsonl\")` before project-root resolution. Any invocation from a subtree without a `.corvia/` above created one wherever the binary ran. Fix: new `resolve_trace_path(&cli)` resolves via `discover::resolve_base_dir` + `Config::load_discovered` and passes an absolute path; `init_telemetry`'s `None` arm now skips the file exporter instead of defaulting to cwd-relative.
- **Shadow detection**: `find_project_root` used to stop at the first `.corvia/corvia.toml` it hit. When an accidental `corvia init` planted a store in a sub-dir, every subsequent invocation from that subtree silently used the inner store. Fix: walk-up completes, collects all enclosing matches, returns the closest (behavior unchanged), and emits `tracing::warn!` listing every shadowed ancestor.

## Test plan
- [x] `cargo test --workspace --lib` (104 passed, 0 failed)
- [x] 2 new unit tests: `shadowed_enclosing_root_is_detected`, `no_shadowed_ancestors_when_only_one_root`
- [x] E2E: rebuilt binary invoked from `repos/corvia/`, `.devcontainer/`, `/tmp/empty-dir/`. None create `.corvia/` outside the discovered project root. From `/tmp/` with no enclosing root, errors cleanly with no stray dir.

## Notes
- `init_telemetry`'s `None` semantics changed (`None` → no file exporter, previously `None` → default `.corvia/traces.jsonl`). Only internal caller is `main.rs`; no external API impact.
- The warning uses `tracing::warn!` which integrates with the existing subscriber/OTLP pipeline. It fires via `load_config` at subcommand entry (subscriber is up by then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)